### PR TITLE
Improve timeline layout for mobile

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -3,6 +3,44 @@
   display: none !important;
 }
 
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #f5f5f7;
+  margin: 0;
+  padding: 0;
+}
+
+.page {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.tab-nav {
+  display: flex;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: #fff;
+  border-bottom: 1px solid #ddd;
+}
+
+.tab-nav button {
+  flex: 1;
+  padding: 0.75rem 0;
+  background: none;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #555;
+  cursor: pointer;
+}
+
+.tab-nav button.active {
+  color: #000;
+  border-bottom: 3px solid #0077cc;
+}
+
 /* Remove default list bullets & spacing */
 #planning-list {
   list-style: none;
@@ -17,8 +55,11 @@
 
 #map {
   width: 100%;
-  height: 400px; /* or any height you prefer */
+  height: 50vh;
+  min-height: 300px;
   margin-bottom: 1rem;
+  border-radius: 0.5rem;
+  overflow: hidden;
 }
 
 /* make cards pop off the page */
@@ -93,4 +134,52 @@
 }
 .stop-card .links a:hover {
   text-decoration: underline;
+}
+
+/* timeline layout */
+#planning-list.timeline {
+  position: relative;
+  padding-left: 2rem;
+  border-left: 3px solid #d0d0d0;
+}
+#planning-list.timeline .stop-card {
+  position: relative;
+  border-left: none;
+  margin-bottom: 2rem;
+}
+#planning-list.timeline .stop-card::before {
+  content: '';
+  position: absolute;
+  left: -11px;
+  top: 1.3rem;
+  width: 14px;
+  height: 14px;
+  background: var(--marker-color, #0077cc);
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px #ccc;
+}
+#planning-list.timeline .stop-card.overnight {
+  --marker-color: #ff9800;
+  border-left-color: #ff9800;
+}
+.stop-card .stay {
+  margin-bottom: 0.75rem;
+  color: #444;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 600px) {
+  #map {
+    height: 40vh;
+  }
+  .stop-card {
+    padding: 1rem;
+  }
+  #planning-list.timeline {
+    padding-left: 1.5rem;
+  }
+  .stop-card h4 {
+    font-size: 1.1rem;
+  }
 }

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -1,9 +1,12 @@
 <!–– Leaflet styles ––>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link
   rel="stylesheet"
   href="https://unpkg.com/leaflet/dist/leaflet.css"
 />
 <link rel="stylesheet" href="/css/captains-log.css">
+
+<main class="page">
 
 <div class="tab-nav">
   <button data-tab="planning" class="active">Planning</button>
@@ -49,6 +52,8 @@
     </ul>
   <% }) %>
 </section>
+
+</main>
 
 <!-– Leaflet core ––>
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>


### PR DESCRIPTION
## Summary
- apply modern timeline styles
- add sticky tab navigation and responsive map height
- include viewport meta tag and page wrapper

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run format` *(fails: No parser could be inferred for views/captains-log.ejs)*

------
https://chatgpt.com/codex/tasks/task_e_68892c46a29c832b8e2b45303d77dab9