### PR TITLE
Present trip plan in tabular format

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -3,94 +3,94 @@
   display: none !important;
 }
 
-/* Remove default list bullets & spacing */
-#planning-list {
-  list-style: none;
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #f5f5f7;
   margin: 0;
   padding: 0;
 }
-#planning-list li {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+
+.page {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.tab-nav {
+  display: flex;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: #fff;
+  border-bottom: 1px solid #ddd;
+}
+
+.tab-nav button {
+  flex: 1;
+  padding: 0.75rem 0;
+  background: none;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #555;
+  cursor: pointer;
+}
+
+.tab-nav button.active {
+  color: #000;
+  border-bottom: 3px solid #0077cc;
+}
+
+/* planning table */
+.stop-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #ffffff;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+  margin-bottom: 1rem;
+}
+.stop-table th,
+.stop-table td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #eee;
+  font-size: 0.9rem;
+}
+.stop-table thead {
+  background: #f0f0f0;
+}
+.stop-table tbody tr:nth-child(even) {
+  background: #fafafa;
+}
+.stop-table tbody tr.overnight {
+  background: #fff8e1;
+}
+.stop-table a {
+  color: #0077cc;
+  text-decoration: none;
+}
+.stop-table a:hover {
+  text-decoration: underline;
+}
+.day-row th {
+  background: #0077cc;
+  color: #fff;
+  font-size: 1rem;
 }
 
 #map {
   width: 100%;
-  height: 400px; /* or any height you prefer */
+  height: 50vh;
+  min-height: 300px;
   margin-bottom: 1rem;
-}
-
-/* make cards pop off the page */
-.stop-card {
-  background: #ffffff;
   border-radius: 0.5rem;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-  border-left: 4px solid #0077cc;  /* accent line */
-  padding: 1.2rem;
-  margin-bottom: 1rem;
-  transition: transform 0.15s, box-shadow 0.15s;
-  cursor: pointer;
-}
-.stop-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 6px 16px rgba(0,0,0,0.1);
+  overflow: hidden;
 }
 
-/* title and subtitle */
-.stop-card h4 {
-  margin: 0 0 0.35rem;
-  font-size: 1.25rem;
-  line-height: 1.2;
-  color: #333;
-}
-.stop-card .subtitle {
-  font-size: 0.9rem;
-  color: #666;
-  margin-bottom: 0.75rem;
-}
-
-/* badge container */
-.stop-card .header {
-  margin-bottom: 0.6rem;
-}
-
-/* Trello label badges */
-.stop-card .label {
-  display: inline-block;
-  padding: 0.25rem 0.6rem;
-  margin-right: 0.4rem;
-  margin-bottom: 0.4rem;
-  border-radius: 0.3rem;
-  font-size: 0.75rem;
-  font-weight: bold;
-}
-
-/* star rating */
-.stop-card .rating {
-  margin-bottom: 0.75rem;
-  font-size: 1.1rem;
-  color: gold;
-  line-height: 1;
-}
-
-/* info line (distance & ETA) */
-.stop-card .info {
-  font-style: italic;
-  color: #555;
-  margin-bottom: 0.75rem;
-}
-
-/* Trello & Navily links */
-.stop-card .links {
-  font-size: 0.85rem;
-  margin-top: 0.5rem;
-}
-.stop-card .links a {
-  text-decoration: none;
-  color: #0077cc;
-  margin-right: 1rem;
-}
-.stop-card .links a:hover {
-  text-decoration: underline;
+@media (max-width: 600px) {
+  #map {
+    height: 40vh;
+  }
 }

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -3,83 +3,69 @@
 // Haversine → meters
 function haversine(lat1, lon1, lat2, lon2) {
   const R = 6371000;
-  const φ1 = lat1 * Math.PI/180, φ2 = lat2 * Math.PI/180;
-  const dφ = (lat2 - lat1) * Math.PI/180;
-  const dλ = (lon2 - lon1) * Math.PI/180;
-  const a = Math.sin(dφ/2)**2 +
-            Math.cos(φ1)*Math.cos(φ2)*Math.sin(dλ/2)**2;
-  return 2 * R * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+  const φ1 = (lat1 * Math.PI) / 180,
+    φ2 = (lat2 * Math.PI) / 180;
+  const dφ = ((lat2 - lat1) * Math.PI) / 180;
+  const dλ = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dφ / 2) ** 2 + Math.cos(φ1) * Math.cos(φ2) * Math.sin(dλ / 2) ** 2;
+  return 2 * R * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
-function toNM(m) { return m/1852; }
+function toNM(m) {
+  return m / 1852;
+}
 function formatDuration(h) {
-  const hh = Math.floor(h), mm = Math.round((h - hh)*60);
+  const hh = Math.floor(h),
+    mm = Math.round((h - hh) * 60);
   return `${hh}h ${mm}m`;
 }
 
 async function fetchData() {
-  const res = await fetch('/api/data');
+  const res = await fetch("/api/data");
   return res.json();
 }
 
 // map rating 1–5 → color
 function getColorForRating(r) {
-  if (r == null)       return '#888888'; // gray
-  if (r <= 1)          return '#d73027';
-  if (r <= 2)          return '#fc8d59';
-  if (r <= 3)          return '#fee08b';
-  if (r <= 4)          return '#d9ef8b';
-  return '#1a9850';     // 5
-}
-
-// helper to decide badge text‑color based on background
-function badgeTextColor(bg) {
-  const light = ['yellow','lime','pink','orange','sky'];
-  return light.includes(bg) ? '#000' : '#fff';
-}
-
-// helper to build a 5‑star string from 1–5
-function makeStars(n) {
-  if (n == null) return '';
-  const full = '★'.repeat(n);
-  const empty = '☆'.repeat(5 - n);
-  return full + empty;
+  if (r == null) return "#888888"; // gray
+  if (r <= 1) return "#d73027";
+  if (r <= 2) return "#fc8d59";
+  if (r <= 3) return "#fee08b";
+  if (r <= 4) return "#d9ef8b";
+  return "#1a9850"; // 5
 }
 
 function initMap(stops, places) {
-  const map = L.map('map').setView([0,0], 2);
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png')
-    .addTo(map);
+  const map = L.map("map").setView([0, 0], 2);
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(map);
 
   const stopCoords = [];
 
   // plot planned stops only
-  stops.forEach(s => {
+  stops.forEach((s) => {
     const ll = [s.lat, s.lng];
     stopCoords.push(ll);
 
     // choose color: blue for current, else by rating
-    const color = s.dueComplete
-      ? '#3182bd'
-      : getColorForRating(s.rating);
+    const color = s.dueComplete ? "#3182bd" : getColorForRating(s.rating);
 
-      console.log(`Stop "${s.name}" rating=${s.rating} → color=${color}`);
+    console.log(`Stop "${s.name}" rating=${s.rating} → color=${color}`);
 
     L.circleMarker(ll, {
       radius: 7,
-      fillColor:   color,
-      color:       '#000',
-      weight:      1,
-      fillOpacity: 0.8
+      fillColor: color,
+      color: "#000",
+      weight: 1,
+      fillOpacity: 0.8,
     })
-    .addTo(map)
-    .bindPopup(
-      `<strong>${s.dueComplete ? 'Current:' : ''} ${s.name}</strong><br>` +
-      (s.dueComplete
-        ? ''
-        : `${new Date(s.due).toLocaleDateString()}<br>` +
-          `Rating: ${s.rating ?? '–'}/5`
-      )
-    );
+      .addTo(map)
+      .bindPopup(
+        `<strong>${s.dueComplete ? "Current:" : ""} ${s.name}</strong><br>` +
+          (s.dueComplete
+            ? ""
+            : `${new Date(s.due).toLocaleDateString()}<br>` +
+              `Rating: ${s.rating ?? "–"}/5`),
+      );
   });
 
   // fit to stops only
@@ -88,158 +74,144 @@ function initMap(stops, places) {
   }
 
   // plot other places without changing zoom
-  places.forEach(p => {
+  places.forEach((p) => {
     const ll = [p.lat, p.lng];
     const color = getColorForRating(p.rating);
     L.circleMarker(ll, {
       radius: 6,
-      fillColor:   color,
-      color:       '#000',
-      weight:      1,
-      fillOpacity: 0.5
+      fillColor: color,
+      color: "#000",
+      weight: 1,
+      fillOpacity: 0.5,
     })
-    .addTo(map)
-    .bindPopup(
-      `<strong>${p.name}</strong><br>` +
-      `Rating: ${p.rating ?? '–'}/5`
-    );
+      .addTo(map)
+      .bindPopup(
+        `<strong>${p.name}</strong><br>` + `Rating: ${p.rating ?? "–"}/5`,
+      );
   });
 }
 
-
 function renderList(stops, speed) {
-  const listEl = document.getElementById('planning-list');
-  listEl.innerHTML = '';
+  const tableEl = document.getElementById("planning-table");
+  tableEl.innerHTML = `
+    <thead>
+      <tr>
+        <th>Stop</th>
+        <th>Distance (NM)</th>
+        <th>ETA</th>
+        <th>Stay</th>
+        <th>Navily</th>
+        <th>Trello</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  `;
 
-  // 1) Render current location (dueComplete === true)
-  const current = stops.find(s => s.dueComplete);
+  const tbody = tableEl.querySelector("tbody");
+
+  const current = stops.find((s) => s.dueComplete);
+  let prevStop = current;
   if (current) {
-    const li = document.createElement('li');
-    li.className = 'stop-card';
-    li.onclick = () => window.open(current.trelloUrl, '_blank');
-
-    // badges for any Trello labels
-    const labels = Array.isArray(current.labels) ? current.labels : [];
-    const badges = labels
-      .map(l => {
-        const bg = l.color || '#888';
-        const fg = badgeTextColor(bg);
-        return `<span class="label" style="background:${bg};color:${fg}">${l.name}</span>`;
-      })
-      .join('');
-
-    // star‑rating
-    const stars = makeStars(current.rating);
-    const ratingHtml = stars ? `<div class="rating">${stars}</div>` : '';
-
-    li.innerHTML = `
-      <div class="header">${badges}</div>
-      <h4>Current: ${current.name}</h4>
-      <div class="subtitle">${current.listName}</div>
-      ${ratingHtml}
-      <div class="links">
-        <a href="${current.trelloUrl}" target="_blank">Trello</a>
-      </div>
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>Current: ${current.name}</td>
+      <td></td><td></td><td></td>
+      <td>${current.navilyUrl ? `<a href="${current.navilyUrl}" target="_blank">Link</a>` : ""}</td>
+      <td><a href="${current.trelloUrl}" target="_blank">Link</a></td>
     `;
-    listEl.appendChild(li);
+    tbody.appendChild(tr);
   }
 
-  // 2) Group all future stops by calendar day
-  const future = stops.filter(s => !s.dueComplete);
+  const future = stops.filter((s) => !s.dueComplete);
+  future.forEach((s, idx) => {
+    const next = future[idx + 1];
+    if (next) {
+      const diff = new Date(next.due) - new Date(s.due);
+      s.hoursToNext = diff / 3600000;
+      s.overnight = next.due.slice(0, 10) !== s.due.slice(0, 10);
+    } else {
+      s.hoursToNext = null;
+      s.overnight = false;
+    }
+  });
+
   const byDay = future.reduce((acc, s) => {
-    const day = s.due.slice(0,10); // "YYYY-MM-DD"
+    const day = s.due.slice(0, 10);
     (acc[day] ??= []).push(s);
     return acc;
   }, {});
 
-  // 3) Iterate each day in order
-  Object.keys(byDay).sort().forEach(dayKey => {
-    // Day header
-    const dateHeader = document.createElement('h3');
-    dateHeader.textContent = new Date(dayKey).toLocaleDateString();
-    listEl.appendChild(dateHeader);
+  Object.keys(byDay)
+    .sort()
+    .forEach((dayKey) => {
+      const dayRow = document.createElement("tr");
+      dayRow.className = "day-row";
+      const th = document.createElement("th");
+      th.colSpan = 6;
+      th.textContent = new Date(dayKey).toLocaleDateString();
+      dayRow.appendChild(th);
+      tbody.appendChild(dayRow);
 
-    // Stops for that day
-    byDay[dayKey].forEach((s, idx, arr) => {
-      // A) compute distance & ETA from previous point
-      const prev = idx === 0
-        ? current || null
-        : arr[idx - 1];
-      let infoHtml = '';
-      if (prev) {
-        const meters = haversine(prev.lat, prev.lng, s.lat, s.lng);
-        const nm     = toNM(meters);
-        const eta    = formatDuration(nm / speed);
-        infoHtml = `<em>${nm.toFixed(1)} NM, ETA: ${eta}</em>`;
-      }
+      byDay[dayKey].forEach((s) => {
+        let distance = "";
+        let eta = "";
+        if (prevStop) {
+          const meters = haversine(prevStop.lat, prevStop.lng, s.lat, s.lng);
+          const nm = toNM(meters);
+          distance = nm.toFixed(1);
+          eta = formatDuration(nm / speed);
+        }
 
-      // B) badges for labels (safe fallback)
-      const labels = Array.isArray(s.labels) ? s.labels : [];
-      const badges = labels
-        .map(l => {
-          const bg = l.color || '#888';
-          const fg = badgeTextColor(bg);
-          return `<span class="label" style="background:${bg};color:${fg}">${l.name}</span>`;
-        })
-        .join('');
+        let stay = "";
+        if (s.hoursToNext != null) {
+          const hrs = Math.round(s.hoursToNext);
+          stay = `${hrs}h ${s.overnight ? "Overnight" : "Lunchtime swim"}`;
+        }
 
-      // C) star‑rating
-      const stars = makeStars(s.rating);
-      const ratingHtml = stars ? `<div class="rating">${stars}</div>` : '';
-
-      // D) build the card
-      const li = document.createElement('li');
-      li.className = 'stop-card';
-      li.onclick   = () => window.open(s.trelloUrl, '_blank');
-
-      li.innerHTML = `
-        <div class="header">${badges}</div>
-        <h4>${s.name}</h4>
-        <div class="subtitle">${s.listName}</div>
-        ${ratingHtml}
-        <div class="info">${infoHtml}</div>
-        <div class="links">
-          <a href="${s.trelloUrl}"  target="_blank">Trello</a>
-          ${s.navilyUrl
-            ? `<a href="${s.navilyUrl}" target="_blank">Navily</a>`
-            : ''}
-        </div>
+        const tr = document.createElement("tr");
+        if (s.overnight) tr.classList.add("overnight");
+        tr.innerHTML = `
+        <td>${s.name}</td>
+        <td>${distance}</td>
+        <td>${eta}</td>
+        <td>${stay}</td>
+        <td>${s.navilyUrl ? `<a href="${s.navilyUrl}" target="_blank">Link</a>` : ""}</td>
+        <td><a href="${s.trelloUrl}" target="_blank">Link</a></td>
       `;
-      listEl.appendChild(li);
+        tbody.appendChild(tr);
+        prevStop = s;
+      });
     });
-  });
 }
 
-
 function initTabs() {
-  document.querySelectorAll('.tab-nav button').forEach(btn=>{
-    btn.addEventListener('click',()=>{
-      document.querySelectorAll('.tab-nav button')
-        .forEach(b=>b.classList.remove('active'));
-      document.querySelectorAll('.tab-content')
-        .forEach(s=>s.classList.add('hidden'));
-      btn.classList.add('active');
-      document.getElementById(btn.dataset.tab)
-        .classList.remove('hidden');
+  document.querySelectorAll(".tab-nav button").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      document
+        .querySelectorAll(".tab-nav button")
+        .forEach((b) => b.classList.remove("active"));
+      document
+        .querySelectorAll(".tab-content")
+        .forEach((s) => s.classList.add("hidden"));
+      btn.classList.add("active");
+      document.getElementById(btn.dataset.tab).classList.remove("hidden");
     });
   });
 }
 
 async function init() {
-  const { stops, places } = await fetchData();    // server has already excluded Trips
-  console.log('Planned stops:', stops);
+  const { stops, places } = await fetchData(); // server has already excluded Trips
+  console.log("Planned stops:", stops);
 
-  const speedInput = document.getElementById('speed-input');
+  const speedInput = document.getElementById("speed-input");
   initMap(stops, places);
   renderList(stops, parseFloat(speedInput.value));
 
-  speedInput.addEventListener('input', () => {
+  speedInput.addEventListener("input", () => {
     renderList(stops, parseFloat(speedInput.value) || 0);
   });
 
   initTabs();
 }
 
-
-
-document.addEventListener('DOMContentLoaded', init);
+document.addEventListener("DOMContentLoaded", init);

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -1,9 +1,12 @@
 <!–– Leaflet styles ––>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link
   rel="stylesheet"
   href="https://unpkg.com/leaflet/dist/leaflet.css"
 />
 <link rel="stylesheet" href="/css/captains-log.css">
+
+<main class="page">
 
 <div class="tab-nav">
   <button data-tab="planning" class="active">Planning</button>
@@ -26,7 +29,7 @@
   </div>
 
   <div id="map"></div>
-  <ul id="planning-list" class="stop-list"></ul>
+  <table id="planning-table" class="stop-table"></table>
 </section>
 
 
@@ -49,6 +52,8 @@
     </ul>
   <% }) %>
 </section>
+
+</main>
 
 <!-– Leaflet core ––>
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>


### PR DESCRIPTION
## Summary
- replace stop timeline with a table listing name, distance, ETA, stay type, and Navily/Trello links
- group stops by day and mark overnight vs lunchtime swim durations
- style the planning table for improved readability with zebra rows and overnight highlighting

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run format` *(fails: No parser could be inferred for views/captains-log.ejs)*

------
https://chatgpt.com/codex/tasks/task_e_68892c46a29c832b8e2b45303d77dab9