### PR TITLE
Allow optional Trello sign-in with separate credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Captain's Log
+
+This project now supports optional Trello authentication so that users can sign in with their Trello accounts. Without signing in the app continues to show read‑only board data; after authentication it will have read/write access to the user's Trello data which will enable future editing features.
+
+## Environment Variables
+
+Set the following variables in a `.env` file or your environment:
+
+```
+# Used for fetching read‑only board data
+TRELLO_KEY=<your trello api key>
+TRELLO_TOKEN=<trello token with read access>
+TRELLO_BOARD_ID=<board id>
+
+# Used for Trello OAuth login
+TRELLO_OAUTH_KEY=<your trello OAuth key>
+TRELLO_OAUTH_SECRET=<your trello OAuth secret>
+
+# Session/host configuration
+SESSION_SECRET=<session secret>
+BASE_URL=http://localhost:3000
+```
+
+## Authentication
+
+If `TRELLO_OAUTH_KEY` and `TRELLO_OAUTH_SECRET` are provided you can navigate to `/auth/trello` to start the OAuth flow. After authorizing, Trello will redirect back to `/auth/trello/callback` and your session will be authenticated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,11 @@
         "dotenv": "^16.0.0",
         "ejs": "^3.1.9",
         "express": "^4.18.2",
+        "express-session": "^1.18.2",
         "helmet": "^7.0.0",
-        "morgan": "^1.10.0"
+        "morgan": "^1.10.0",
+        "passport": "^0.7.0",
+        "passport-trello": "^1.1.0"
       },
       "devDependencies": {
         "eslint": "^8.50.0",
@@ -1070,6 +1073,40 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1951,6 +1988,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -2066,6 +2109,62 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-oauth1": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.3.0.tgz",
+      "integrity": "sha512-8T/nX4gwKTw0PjxP1xfD0QhrydQNakzeOpZ6M5Uqdgz9/a/Ag62RmJxnZQ4LkbdXGrRehQHIAHNAu11rCP46Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-trello": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/passport-trello/-/passport-trello-1.1.0.tgz",
+      "integrity": "sha512-mjYVdDQ0MrzOhPn8GxEqck0nUjr7o1KKGvNBgKdUZySaptXeHzfH39KKBmmfTYvSM4COfci9Di2O76gXYZPzOg==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth1": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2101,6 +2200,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -2212,6 +2316,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -2642,6 +2755,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/undefsafe": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,11 @@
     "dotenv": "^16.0.0",
     "ejs": "^3.1.9",
     "express": "^4.18.2",
+    "express-session": "^1.18.2",
     "helmet": "^7.0.0",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "passport": "^0.7.0",
+    "passport-trello": "^1.1.0"
   },
   "devDependencies": {
     "eslint": "^8.50.0",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const passport = require('passport');
+
+const router = express.Router();
+
+// Initiates Trello authentication (only if strategy is configured)
+router.get('/trello', (req, res, next) => {
+  const strat = passport._strategy('trello');
+  if (!strat) return res.status(503).send('Trello login not configured');
+  passport.authenticate('trello')(req, res, next);
+});
+
+// Callback URL Trello will redirect to after authorization
+router.get('/trello/callback', (req, res, next) => {
+  const strat = passport._strategy('trello');
+  if (!strat) return res.status(503).send('Trello login not configured');
+  passport.authenticate('trello', { failureRedirect: '/login?error=trello' })(req, res, next);
+},
+  (req, res) => {
+    // Successful authentication, redirect home or desired page
+    res.redirect('/');
+  }
+);
+
+// Logs the user out and clears their session
+router.get('/logout', (req, res, next) => {
+  req.logout(err => {
+    if (err) { return next(err); }
+    res.redirect('/');
+  });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add distinct `TRELLO_OAUTH_KEY`/`TRELLO_OAUTH_SECRET` env vars for Trello login
- fallback gracefully when OAuth creds are missing
- document both read-only and OAuth variables in README

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a2345504b4832bb5b6dd5f765c723a