### PR TITLE
Derive Trello callback URL from request

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@ TRELLO_OAUTH_SECRET=<your trello OAuth secret>
 
 # Session/host configuration
 SESSION_SECRET=<session secret>
-BASE_URL=http://localhost:3000
 ```
+
+The application derives its base URL from incoming requests, so no `BASE_URL`
+environment variable is required. The Trello login route builds the callback
+URL from `req.protocol` and `req.get('host')`, ensuring Trello receives the
+correct absolute URL for each request.
 
 ## Authentication
 

--- a/app.js
+++ b/app.js
@@ -78,7 +78,6 @@ if (process.env.TRELLO_OAUTH_KEY && process.env.TRELLO_OAUTH_SECRET) {
       {
         consumerKey: process.env.TRELLO_OAUTH_KEY,
         consumerSecret: process.env.TRELLO_OAUTH_SECRET,
-        callbackURL: `${process.env.BASE_URL || 'http://localhost:3000'}/auth/trello/callback`,
         trelloParams: { scope: 'read,write', expiration: '1day' }
       },
       (token, tokenSecret, profile, done) => {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -7,7 +7,10 @@ const router = express.Router();
 router.get('/trello', (req, res, next) => {
   const strat = passport._strategy('trello');
   if (!strat) return res.status(503).send('Trello login not configured');
-  passport.authenticate('trello')(req, res, next);
+  const baseUrl = `${req.protocol}://${req.get('host')}`;
+  passport.authenticate('trello', {
+    callbackURL: `${baseUrl}/auth/trello/callback`
+  })(req, res, next);
 });
 
 // Callback URL Trello will redirect to after authorization


### PR DESCRIPTION
## Summary
- build Trello OAuth callback URL from the request's protocol and host
- document how the callback URL is derived without a BASE_URL variable

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a43e192ce4832b825981aff220cd27