### PR TITLE
feat: trust proxy for https callback behind Railway

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,6 +92,7 @@ if (process.env.TRELLO_OAUTH_KEY && process.env.TRELLO_OAUTH_SECRET) {
   console.warn('Trello OAuth environment variables not set; login will be disabled');
 }
 
+app.set('trust proxy', true);
 app.use('/auth', auth);
 app.use('/', captainsLog);
 


### PR DESCRIPTION
## Summary
- ensure Express trusts Railway proxy so `req.protocol` resolves to `https`

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a551f9e5f8832b81be8a917428c0ad