### PR TITLE
Add deployment subpath to Trello callback URL

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -7,7 +7,9 @@ const router = express.Router();
 router.get('/trello', (req, res, next) => {
   const strat = passport._strategy('trello');
   if (!strat) return res.status(503).send('Trello login not configured');
-  passport.authenticate('trello')(req, res, next);
+  const basePath = req.baseUrl || '/captains-log';
+  const callbackURL = `${req.protocol}://${req.get('host')}${basePath}/auth/trello/callback`;
+  passport.authenticate('trello', { callbackURL })(req, res, next);
 });
 
 // Callback URL Trello will redirect to after authorization


### PR DESCRIPTION
## Summary
- Ensure Trello auth callback uses deployment subpath when constructing callback URL

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a551fb4fdc832bb1fd8c542a82bd06