### PR TITLE
Enable planning future stops from map

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -561,6 +561,12 @@ body {
   color: #0077cc;
   font-size: 1.2em;
 }
+
+.plan-btn {
+  margin-top: 0.5em;
+  padding: 0.3em 0.6em;
+  cursor: pointer;
+}
 @media (max-width: 899px) {
   .log-table {
     display: table;

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1,5 +1,7 @@
 // public/js/captains-log.js
 
+const LOGGED_IN = document.querySelector('main.page')?.dataset.loggedIn === 'true';
+
 let leafletMap = null;
 
 // Store the last loaded logs for filtering
@@ -184,7 +186,7 @@ function initMap(stops, places) {
     }).addTo(map);
 
     let popupHtml = `<strong>${p.name}</strong><br>` + `Rating: ${p.rating ?? "–"}/5`;
-    if (window.LOGGED_IN) {
+    if (LOGGED_IN) {
       popupHtml += `<br><button class="plan-btn" data-card-id="${p.id}">Plan</button>`;
     }
     marker.bindPopup(popupHtml).bindTooltip(p.name, {
@@ -194,7 +196,7 @@ function initMap(stops, places) {
       className: "map-label"
     });
 
-    if (window.LOGGED_IN) {
+    if (LOGGED_IN) {
       marker.on('popupopen', () => {
         const btn = document.querySelector('.plan-btn');
         if (btn) {

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -67,6 +67,9 @@ async function refreshPlanningUI() {
 async function planStop(cardId) {
   try {
     const res = await fetch(`/api/plan/${cardId}`, { method: "POST" });
+    if (res.status === 403) {
+      throw new Error("Unauthorized");
+    }
     if (!res.ok) throw new Error("Request failed");
     await refreshPlanningUI();
   } catch (err) {

--- a/routes/captainsLog.js
+++ b/routes/captainsLog.js
@@ -4,7 +4,8 @@ const {
   fetchBoard,
   fetchAllComments,
   fetchBoardWithAllComments,
-  setCardDueDate
+  setCardDueDate,
+  isBoardMember
 } = require('../services/trello');
 
 // existing number helper
@@ -34,13 +35,16 @@ function getCFTextOrDropdown(card, boardCFs, name) {
   return null;
 }
 
-function ensureBoardMember(req, res, next) {
-  const boardId = process.env.TRELLO_BOARD_ID;
-  const boards = req.user && req.user._json && req.user._json.idBoards;
-  if (req.user && Array.isArray(boards) && boards.includes(boardId)) {
-    return next();
+async function ensureBoardMember(req, res, next) {
+  try {
+    const userId = req.user && req.user.id;
+    if (userId && await isBoardMember(userId)) {
+      return next();
+    }
+    return res.status(403).json({ error: 'Unauthorized' });
+  } catch (err) {
+    next(err);
   }
-  return res.status(403).json({ error: 'Unauthorized' });
 }
 
 router.get('/api/data', async (req, res, next) => {

--- a/services/trello.js
+++ b/services/trello.js
@@ -44,9 +44,23 @@ async function setCardDueDate(cardId, due) {
   await axios.put(url, null, { params: { key: KEY, token: TOKEN, due } });
 }
 
+async function isBoardMember(memberId) {
+  const url = `https://api.trello.com/1/boards/${BOARD_ID}/members/${memberId}`;
+  try {
+    await axios.get(url, { params: { key: KEY, token: TOKEN } });
+    return true;
+  } catch (err) {
+    if (err.response && err.response.status === 404) {
+      return false;
+    }
+    throw err;
+  }
+}
+
 module.exports = {
   fetchBoard,
   fetchAllComments,
   fetchBoardWithAllComments,
-  setCardDueDate
+  setCardDueDate,
+  isBoardMember
 };

--- a/services/trello.js
+++ b/services/trello.js
@@ -39,4 +39,14 @@ async function fetchBoardWithAllComments() {
   return board;
 }
 
-module.exports = { fetchBoard, fetchAllComments, fetchBoardWithAllComments };
+async function setCardDueDate(cardId, due) {
+  const url = `https://api.trello.com/1/cards/${cardId}`;
+  await axios.put(url, null, { params: { key: KEY, token: TOKEN, due } });
+}
+
+module.exports = {
+  fetchBoard,
+  fetchAllComments,
+  fetchBoardWithAllComments,
+  setCardDueDate
+};

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -96,4 +96,5 @@
 <!-– Leaflet core ––>
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <!–– Your app JS ––>
+<script>window.LOGGED_IN = <%= user ? 'true' : 'false' %>;</script>
 <script src="/js/captains-log.js"></script>

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="https://unpkg.com/@fortawesome/fontawesome-free@6.4.2/css/all.min.css">
 <link rel="stylesheet" href="/css/captains-log.css">
 
-<main class="page">
+<main class="page" data-logged-in="<%= user ? 'true' : 'false' %>">
 
 <header class="site-header">
   <div class="site-title">Where is ...</div>
@@ -96,5 +96,4 @@
 <!-– Leaflet core ––>
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <!–– Your app JS ––>
-<script>window.LOGGED_IN = <%= user ? 'true' : 'false' %>;</script>
 <script src="/js/captains-log.js"></script>


### PR DESCRIPTION
## Summary
- add Trello service to set card due dates
- allow board members to plan stops via new `/api/plan` endpoint
- expose login flag and add “Plan” map button that refreshes planning data

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ad30ad44832ba1653850503a0c5d