### PR TITLE
Enable planning future stops from map

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -561,6 +561,12 @@ body {
   color: #0077cc;
   font-size: 1.2em;
 }
+
+.plan-btn {
+  margin-top: 0.5em;
+  padding: 0.3em 0.6em;
+  cursor: pointer;
+}
 @media (max-width: 899px) {
   .log-table {
     display: table;

--- a/services/trello.js
+++ b/services/trello.js
@@ -39,4 +39,28 @@ async function fetchBoardWithAllComments() {
   return board;
 }
 
-module.exports = { fetchBoard, fetchAllComments, fetchBoardWithAllComments };
+async function setCardDueDate(cardId, due) {
+  const url = `https://api.trello.com/1/cards/${cardId}`;
+  await axios.put(url, null, { params: { key: KEY, token: TOKEN, due } });
+}
+
+async function isBoardMember(memberId) {
+  const url = `https://api.trello.com/1/boards/${BOARD_ID}/members/${memberId}`;
+  try {
+    await axios.get(url, { params: { key: KEY, token: TOKEN } });
+    return true;
+  } catch (err) {
+    if (err.response && err.response.status === 404) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+module.exports = {
+  fetchBoard,
+  fetchAllComments,
+  fetchBoardWithAllComments,
+  setCardDueDate,
+  isBoardMember
+};

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="https://unpkg.com/@fortawesome/fontawesome-free@6.4.2/css/all.min.css">
 <link rel="stylesheet" href="/css/captains-log.css">
 
-<main class="page">
+<main class="page" data-logged-in="<%= user ? 'true' : 'false' %>" data-board-member="<%= boardMember ? 'true' : 'false' %>">
 
 <header class="site-header">
   <div class="site-title">Where is ...</div>


### PR DESCRIPTION
## Summary
- add Trello service to set card due dates
- allow board members to plan stops via new `/api/plan` endpoint
- verify board membership against Trello API to avoid 403 errors
- expose login flag and add “Plan” map button that refreshes planning data
- pass login flag via data attribute to satisfy CSP and render the button for logged-in users
- only show planning UI to Trello board members

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ad30ad44832ba1653850503a0c5d