### PR TITLE
Enable planning future stops from map

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -561,6 +561,12 @@ body {
   color: #0077cc;
   font-size: 1.2em;
 }
+
+.plan-btn {
+  margin-top: 0.5em;
+  padding: 0.3em 0.6em;
+  cursor: pointer;
+}
 @media (max-width: 899px) {
   .log-table {
     display: table;

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1,5 +1,7 @@
 // public/js/captains-log.js
 
+const LOGGED_IN = document.querySelector('main.page')?.dataset.loggedIn === 'true';
+
 let leafletMap = null;
 
 // Store the last loaded logs for filtering
@@ -49,6 +51,30 @@ function formatDurationRounded(h) {
 async function fetchData() {
   const res = await fetch("/api/data");
   return res.json();
+}
+
+async function refreshPlanningUI() {
+  const data = await fetchData();
+  stops = data.stops;
+  places = data.places;
+  const speed = parseFloat(document.getElementById("speed-input").value) || 0;
+  renderMapWithToggle();
+  renderTable(stops, speed);
+  renderCards(stops, speed);
+  setupHistoricalTripLinks(stops);
+}
+
+async function planStop(cardId) {
+  try {
+    const res = await fetch(`/api/plan/${cardId}`, { method: "POST", credentials: 'same-origin' });
+    if (res.status === 403) {
+      throw new Error("Unauthorized");
+    }
+    if (!res.ok) throw new Error("Request failed");
+    await refreshPlanningUI();
+  } catch (err) {
+    console.error("Failed to plan stop", err);
+  }
 }
 
 // map rating 1–5 → color
@@ -154,23 +180,33 @@ function initMap(stops, places) {
   places.forEach((p) => {
     const ll = [p.lat, p.lng];
     const color = getColorForRating(p.rating);
-    L.circleMarker(ll, {
+    const marker = L.circleMarker(ll, {
       radius: 10,
       fillColor: color,
       color: "#000",
       weight: 1,
       fillOpacity: 0.5,
-    })
-      .addTo(map)
-      .bindPopup(
-        `<strong>${p.name}</strong><br>` + `Rating: ${p.rating ?? "–"}/5`,
-      )
-      .bindTooltip(p.name, {
-        permanent: false, // only show on hover/tap
-        direction: "right",
-        offset: [10, 0],
-        className: "map-label"
-      })
+    }).addTo(map);
+
+    let popupHtml = `<strong>${p.name}</strong><br>` + `Rating: ${p.rating ?? "–"}/5`;
+    if (LOGGED_IN) {
+      popupHtml += `<br><button class="plan-btn" data-card-id="${p.id}">Plan</button>`;
+    }
+    marker.bindPopup(popupHtml).bindTooltip(p.name, {
+      permanent: false, // only show on hover/tap
+      direction: "right",
+      offset: [10, 0],
+      className: "map-label"
+    });
+
+    if (LOGGED_IN) {
+      marker.on('popupopen', () => {
+        const btn = document.querySelector('.plan-btn');
+        if (btn) {
+          btn.addEventListener('click', () => planStop(p.id), { once: true });
+        }
+      });
+    }
   });
   
   return map;

--- a/services/trello.js
+++ b/services/trello.js
@@ -39,4 +39,28 @@ async function fetchBoardWithAllComments() {
   return board;
 }
 
-module.exports = { fetchBoard, fetchAllComments, fetchBoardWithAllComments };
+async function setCardDueDate(cardId, due) {
+  const url = `https://api.trello.com/1/cards/${cardId}`;
+  await axios.put(url, null, { params: { key: KEY, token: TOKEN, due } });
+}
+
+async function isBoardMember(memberId) {
+  const url = `https://api.trello.com/1/boards/${BOARD_ID}/members/${memberId}`;
+  try {
+    await axios.get(url, { params: { key: KEY, token: TOKEN } });
+    return true;
+  } catch (err) {
+    if (err.response && err.response.status === 404) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+module.exports = {
+  fetchBoard,
+  fetchAllComments,
+  fetchBoardWithAllComments,
+  setCardDueDate,
+  isBoardMember
+};

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="https://unpkg.com/@fortawesome/fontawesome-free@6.4.2/css/all.min.css">
 <link rel="stylesheet" href="/css/captains-log.css">
 
-<main class="page">
+<main class="page" data-logged-in="<%= user ? 'true' : 'false' %>">
 
 <header class="site-header">
   <div class="site-title">Where is ...</div>
@@ -44,11 +44,11 @@
         >
         <span class="speed-units">knots</span>
       </label>
-      <label class="toggle-label">
-        <input type="checkbox" id="planned-only-toggle" checked>
-        <span>Show only planned stops on map</span>
-      </label>
-    </div>
+        <label class="toggle-label">
+          <input type="checkbox" id="planned-only-toggle" <%= boardMember ? '' : 'checked' %>>
+          <span>Show only planned stops on map</span>
+        </label>
+      </div>
     <div id="planning-list" class="mobile-cards"></div>
     <table id="planning-table" class="planning-table"></table>
   </div>


### PR DESCRIPTION
## Summary
- add Trello service to set card due dates
- allow board members to plan stops via new `/api/plan` endpoint
- verify board membership against Trello API to avoid 403 errors
- expose login flag and add “Plan” map button that refreshes planning data
- pass login flag via data attribute to satisfy CSP and render the button for logged-in users
- only show planning UI to Trello board members
- show unplanned stops by default for board members so the Plan button is visible
- show Plan button for any logged-in user and let the server enforce board membership

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ad30ad44832ba1653850503a0c5d