### PR TITLE
Draw sea-only routes between stops

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,7 +42,8 @@ app.use(
       ],
       connectSrc: [
         "'self'",
-        "https://api.trello.com"
+        "https://api.trello.com",
+        "https://routing.openstreetmap.de"
       ],
       fontSrc: [
         "'self'",


### PR DESCRIPTION
## Summary
- add helper to fetch sea-only routes via OpenStreetMap's routed-sea API
- replace straight polylines with water-aware routes on main and log maps
- allow front-end to reach the routed-sea service by whitelisting it in the Content Security Policy
- always render a straight segment if sea routing can't be fetched

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d53e8ad4832ba11012f4f126428d