### PR TITLE
feat: enable PWA installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Captain's Log
+# Where is...
 
-This project now supports optional Trello authentication so that users can sign in with their Trello accounts. Without signing in the app continues to show read‑only board data; after authentication it will have read/write access to the user's Trello data which will enable future editing features.
+This project now supports installation as a Progressive Web App and optional Trello authentication so that users can sign in with their Trello accounts. Without signing in the app continues to show read-only board data; after authentication it will have read/write access to the user's Trello data which will enable future editing features.
 
 ## Environment Variables
 

--- a/app.js
+++ b/app.js
@@ -39,7 +39,8 @@ app.use(
         "data:",                      // marker icons
         "https://*.tile.openstreetmap.org", // map tiles
         "https://unpkg.com",
-        "https://trello-members.s3.amazonaws.com"
+        "https://trello-members.s3.amazonaws.com",
+        "https://api.iconify.design"
       ],
       connectSrc: [
         "'self'",
@@ -48,7 +49,9 @@ app.use(
       fontSrc: [
         "'self'",
         "https://unpkg.com"
-      ]
+      ],
+      workerSrc: ["'self'"],
+      manifestSrc: ["'self'"],
     }
   })
 );

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1243,3 +1243,9 @@ async function init() {
 }
 
 document.addEventListener("DOMContentLoaded", init);
+
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/service-worker.js");
+  });
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Where is...",
+  "short_name": "Where is",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffa500",
+  "icons": [
+    {
+      "src": "https://api.iconify.design/mdi:map-marker.png?color=%23ffa500&width=192&height=192",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "https://api.iconify.design/mdi:map-marker.png?color=%23ffa500&width=512&height=512",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,18 @@
+const CACHE_NAME = 'where-is-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/css/captains-log.css',
+  '/js/captains-log.js',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((resp) => resp || fetch(event.request))
+  );
+});

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -1,5 +1,8 @@
 <!–– Leaflet styles ––>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="manifest" href="/manifest.json">
+<meta name="theme-color" content="#ffa500">
+<link rel="apple-touch-icon" href="https://api.iconify.design/mdi:map-marker.png?color=%23ffa500&width=192&height=192">
 <link
   rel="stylesheet"
   href="https://unpkg.com/leaflet/dist/leaflet.css"


### PR DESCRIPTION
## Summary
- add web app manifest, service worker, and icons
- register service worker and expose manifest
- document new "Where is..." PWA branding
- generate branded map-pin icons for PWA
- use external map-marker icon instead of local assets

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1ffb0b58832b98bb98d954d38cbe