### PR TITLE
Restrict drag-and-drop reordering to logged-in users

### DIFF
--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -682,6 +682,7 @@ function initTableDragAndDrop() {
     tbody._sortable.destroy();
     tbody._sortable = null;
   }
+  if (!canPlan) return;
 
   tbody._sortable = Sortable.create(tbody, {
     handle: 'td',
@@ -745,6 +746,8 @@ function initCardsDragAndDrop() {
       dayDiv._sortable.destroy();
       dayDiv._sortable = null;
     }
+
+    if (!canPlan) return;
 
     dayDiv._sortable = Sortable.create(dayDiv, {
       group: 'stops', // allow cross-day dragging


### PR DESCRIPTION
## Summary
- only initialize Sortable drag-and-drop when a user can plan
- clean up existing Sortable instances if the user isn't allowed to plan

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68acac439734832bbb60487e2766b088