### PR TITLE
Support bare date-time comment overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node app.js",
     "lint": "eslint . --ext .js",
     "format": "prettier --write \"**/*.js\" \"**/*.ejs\"",
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "node --test tests/extractTimestamp.test.js"
   },
   "engines": {
     "node": ">=18"

--- a/routes/captainsLog.js
+++ b/routes/captainsLog.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router  = express.Router();
 const axios = require('axios');
 const { fetchBoard, fetchAllComments, fetchBoardWithAllComments } = require('../services/trello');
+const { extractTimestamp } = require('../services/extractTimestamp');
 
 // existing number helper
 function getCFNumber(card, boardCFs, name) {
@@ -115,18 +116,6 @@ router.get('/api/data', async (req, res, next) => {
         canPlan = members.some(m => m.id === userId && (m.memberType === 'admin' || m.memberType === 'normal'));
       }
       
-      // Helper to extract timestamp from comment text
-      function extractTimestamp(text, fallback) {
-        const match = text.match(/timestamp:\s*([0-9T:\- ]+)/i);
-        if (match) {
-          // Try to parse as ISO or "YYYY-mm-dd hh:mm"
-          const ts = match[1].trim().replace(' ', 'T');
-          const d = new Date(ts.length === 16 ? ts + ':00' : ts); // add seconds if missing
-          if (!isNaN(d)) return d.toISOString();
-        }
-        return fallback;
-      }
-
     res.json({ stops, places, canPlan });
   } catch(err) {
     next(err);
@@ -157,16 +146,6 @@ router.get('/api/logs', async (req, res, next) => {
       }
       return null;
     }
-    function extractTimestamp(text, fallback) {
-      const match = text.match(/timestamp:\s*([0-9T:\- ]+)/i);
-      if (match) {
-        const ts = match[1].trim().replace(' ', 'T');
-        const d = new Date(ts.length === 16 ? ts + ':00' : ts);
-        if (!isNaN(d)) return d.toISOString();
-      }
-      return fallback;
-    }
-
     // Get trips from cards in the Trips list
     const tripsList = lists.find(l => l.name === 'Trips');
     const trips = cards

--- a/services/extractTimestamp.js
+++ b/services/extractTimestamp.js
@@ -1,0 +1,14 @@
+function extractTimestamp(text, fallback) {
+  let match = text.match(/timestamp:\s*(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2})?)/i);
+  if (!match) {
+    match = text.match(/(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2})?)/);
+  }
+  if (match) {
+    const ts = match[1].trim().replace(' ', 'T');
+    const d = new Date(ts.length === 16 ? ts + ':00' : ts);
+    if (!isNaN(d)) return d.toISOString();
+  }
+  return fallback;
+}
+
+module.exports = { extractTimestamp };

--- a/tests/extractTimestamp.test.js
+++ b/tests/extractTimestamp.test.js
@@ -1,0 +1,24 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { extractTimestamp } = require('../services/extractTimestamp');
+
+test('parses lowercase prefix', () => {
+  const result = extractTimestamp('Arrived timestamp: 2025-07-07 10:30', 'fallback');
+  assert.strictEqual(result, '2025-07-07T10:30:00.000Z');
+});
+
+test('parses capitalized prefix', () => {
+  const result = extractTimestamp('Arrived Timestamp: 2025-07-07 10:30', 'fallback');
+  assert.strictEqual(result, '2025-07-07T10:30:00.000Z');
+});
+
+test('parses bare timestamp', () => {
+  const result = extractTimestamp('Arrived 2025-07-07 10:30', 'fallback');
+  assert.strictEqual(result, '2025-07-07T10:30:00.000Z');
+});
+
+test('falls back when missing', () => {
+  const fallback = '2025-06-01T00:00:00.000Z';
+  const result = extractTimestamp('Arrived', fallback);
+  assert.strictEqual(result, fallback);
+});


### PR DESCRIPTION
## Summary
- Move timestamp parsing into reusable helper so log entry prep always honors `timestamp:` and bare `YYYY-mm-dd hh:mm` overrides
- Cover timestamp parsing with node-based unit tests

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68acaedb11bc832ba0bfa328d5b9483b