### PR TITLE
Enable member-only rating in captain's log

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -430,6 +430,10 @@ body {
   }
 }
 
+.stars.editable .star {
+  cursor: pointer;
+}
+
 @media (min-width: 900px) {
   #planning {
     display: flex;


### PR DESCRIPTION
## Summary
- allow authenticated board members to rate visited places via new `/api/rate-place` endpoint
- add editable star widgets in log view to send rating updates
- style interactive stars

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ad86885244832bbf38a7eea0fdb64a