### PR TITLE
feat: surface supply and maintenance notes in log view

### DIFF
--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -96,6 +96,7 @@
     <button id="show-last-trip-btn">Show Current/Last Trip</button>
     <button id="show-all-logs-btn">Show All Logs</button>
   </div>
+  <div id="log-summary" style="margin-bottom:1em;"></div>
   <div id="log-list"></div>
 </section>
 </main>


### PR DESCRIPTION
## Summary
- parse additional card comment types like water, diesel usage, sea temperature, gas tank changes, and repairs
- show latest supply and maintenance entries on log page

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9e58765c832bb1fa5adad9e326b2