### PR TITLE
Add broken items info box to log

### DIFF
--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1233,6 +1233,30 @@ function renderLogSummary(logs = []) {
   div.innerHTML = totalsHtml + latestHtml;
 }
 
+function renderBrokenItems(logs = []) {
+  const div = document.getElementById("broken-items");
+  if (!div) return;
+
+  const itemsByName = {};
+  logs
+    .filter(l => (l.type === "Broken" || l.type === "Fixed") && l.item)
+    .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp))
+    .forEach(l => {
+      itemsByName[l.item] = { item: l.item, fixed: l.type === "Fixed" };
+    });
+
+  const entries = Object.values(itemsByName);
+  if (!entries.length) {
+    div.innerHTML = "";
+    return;
+  }
+
+  const list = entries
+    .map(e => `<li>${e.item}: ${e.fixed ? "Fixed" : "Broken"}</li>`)
+    .join("");
+  div.innerHTML = `<h4>Broken Items</h4><ul>${list}</ul>`;
+}
+
 // Render historical map (only arrived unique places). Uses window.histMap to cleanup.
 function renderLogMap(logs = [], stops = []) {
   console.log("Rendering historical map with", logs.length, "logs and", stops.length, "stops");
@@ -1409,6 +1433,7 @@ function setupLogTab(stops = []) {
     }
     renderHistoricalLog(logsToShow, stops);
     renderLogSummary(logsToShow);
+    renderBrokenItems(logsToShow);
     window._lastLogMapData = logsToShow;
 
     // --- ADD THIS: update the map if the log tab is visible ---
@@ -1512,6 +1537,7 @@ function setupHistoricalTripLinks(stops = []) {
       const filtered = filterLogsByDate(allLogsCache, start, end);
       renderHistoricalLog(filtered, stops);
       renderLogSummary(filtered);
+      renderBrokenItems(filtered);
       renderLogMap(filtered, stops);
     });
   });

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -97,6 +97,7 @@
     <button id="show-all-logs-btn">Show All Logs</button>
   </div>
   <div id="log-summary" style="margin-bottom:1em;"></div>
+  <div id="broken-items" style="margin-bottom:1em;"></div>
   <div id="log-list"></div>
 </section>
 </main>


### PR DESCRIPTION
## Summary
- Display broken items and fix status in a new "Broken Items" box on the log tab
- Compute item status from log entries using new `renderBrokenItems` function
- Update log rendering to refresh broken item list when filtering or selecting trips

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68adb2972588832b89f4b6687dd7b9ce