### PR TITLE
Add broken items info box to log

### DIFF
--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1233,6 +1233,33 @@ function renderLogSummary(logs = []) {
   div.innerHTML = totalsHtml + latestHtml;
 }
 
+function renderBrokenItems(logs = []) {
+  const div = document.getElementById("broken-items");
+  if (!div) return;
+
+  const itemsByName = {};
+  logs
+    .filter(l => (l.type === "Broken" || l.type === "Fixed") && l.item)
+    .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp))
+    .forEach(l => {
+      const cleanItem = l.item
+        .replace(/timestamp:\s*([0-9T:\- ]+)/i, "")
+        .trim();
+      itemsByName[cleanItem] = { item: cleanItem, fixed: l.type === "Fixed" };
+    });
+
+  const entries = Object.values(itemsByName);
+  if (!entries.length) {
+    div.innerHTML = "";
+    return;
+  }
+
+  const list = entries
+    .map(e => `<li>${e.item}: ${e.fixed ? "Fixed" : "Broken"}</li>`)
+    .join("");
+  div.innerHTML = `<h4>Broken Items</h4><ul>${list}</ul>`;
+}
+
 // Render historical map (only arrived unique places). Uses window.histMap to cleanup.
 function renderLogMap(logs = [], stops = []) {
   console.log("Rendering historical map with", logs.length, "logs and", stops.length, "stops");
@@ -1409,6 +1436,7 @@ function setupLogTab(stops = []) {
     }
     renderHistoricalLog(logsToShow, stops);
     renderLogSummary(logsToShow);
+    renderBrokenItems(logsToShow);
     window._lastLogMapData = logsToShow;
 
     // --- ADD THIS: update the map if the log tab is visible ---
@@ -1512,6 +1540,7 @@ function setupHistoricalTripLinks(stops = []) {
       const filtered = filterLogsByDate(allLogsCache, start, end);
       renderHistoricalLog(filtered, stops);
       renderLogSummary(filtered);
+      renderBrokenItems(filtered);
       renderLogMap(filtered, stops);
     });
   });

--- a/routes/captainsLog.js
+++ b/routes/captainsLog.js
@@ -211,10 +211,14 @@ router.get('/api/logs', async (req, res, next) => {
             type = "BBQ gas change";
           } else if (brokenMatch) {
             type = "Broken";
-            item = brokenMatch[1].trim();
+            item = brokenMatch[1]
+              .replace(/timestamp:\s*([0-9T:\- ]+)/i, "")
+              .trim();
           } else if (fixedMatch) {
             type = "Fixed";
-            item = fixedMatch[1].trim();
+            item = fixedMatch[1]
+              .replace(/timestamp:\s*([0-9T:\- ]+)/i, "")
+              .trim();
           }
         }
 

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -97,6 +97,7 @@
     <button id="show-all-logs-btn">Show All Logs</button>
   </div>
   <div id="log-summary" style="margin-bottom:1em;"></div>
+  <div id="broken-items" style="margin-bottom:1em;"></div>
   <div id="log-list"></div>
 </section>
 </main>


### PR DESCRIPTION
## Summary
- Display broken items and fix status in a new "Broken Items" box on the log tab
- Compute item status from log entries using new `renderBrokenItems` function
- Update log rendering to refresh broken item list when filtering or selecting trips
- Strip `timestamp:` metadata from broken item names using the same pattern as `extractTimestamp`

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68adb2972588832b89f4b6687dd7b9ce