### PR TITLE
Link site title to main Where is page

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -38,6 +38,11 @@ body {
   letter-spacing: 0.03em;
 }
 
+.site-title-link {
+  text-decoration: none;
+  color: inherit;
+}
+
 .site-user {
   display: flex;
   align-items: center;

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -10,7 +10,7 @@
 <main class="page">
 
 <header class="site-header">
-  <div class="site-title">Where is ...</div>
+  <div class="site-title"><a href="https://where.is.achilleas.co.uk" class="site-title-link">Where is ...</a></div>
   <div class="site-user">
    <% if (user) { %>
     <div class="user-menu">


### PR DESCRIPTION
## Summary
- make the "Where is..." header link to the main site
- ensure the header link inherits styling without an underline

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae09fc52f0832bbb44b8e3b2406a8f