### PR TITLE
Unify planning layout with responsive table

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -168,67 +168,6 @@ body {
   border-bottom: 3px solid #0077cc;
 }
 
-/* timeline list */
-.timeline {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-.timeline h3 {
-  margin: 1.5rem 0 0.5rem;
-  font-size: 1rem;
-  color: #555;
-}
-.stop-card {
-  position: relative;
-  margin: 0 0 1rem 1.5rem;
-  padding: 1rem;
-  background: #fff;
-  border-left: 3px solid #0077cc;
-  border-radius: 0.5rem;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-}
-.stop-card:before {
-  content: '';
-  position: absolute;
-  left: -0.75rem;
-  top: 1rem;
-  width: 0.75rem;
-  height: 0.75rem;
-  background: #0077cc;
-  border-radius: 50%;
-}
-.stop-card.overnight {
-  border-left-color: #f39c12;
-}
-.stop-card.overnight:before {
-  background: #f39c12;
-}
-.stop-card .header {
-  margin-bottom: 0.25rem;
-}
-.stop-card .subtitle {
-  font-size: 0.85rem;
-  color: #555;
-}
-.stop-card .info {
-  font-size: 0.85rem;
-  color: #555;
-}
-.stop-card .stay {
-  font-size: 0.85rem;
-  color: #555;
-  margin-top: 0.25rem;
-}
-.stop-card .links a {
-  margin-right: 0.75rem;
-  color: #0077cc;
-  text-decoration: none;
-  font-size: 0.85rem;
-}
-.stop-card .links a:hover {
-  text-decoration: underline;
-}
 .label {
   display: inline-block;
   padding: 0.15rem 0.4rem;
@@ -416,27 +355,42 @@ body {
   filter: drop-shadow(0 2px 4px rgba(0,0,0,0.18));
 }
 
-#planning-list {
-  display: none;
-}
-.planning-table {
-  display: table;
+.stars.editable .star {
+  cursor: pointer;
 }
 
 @media (max-width: 899px) {
-  #planning-list {
-    display: flex;
-    flex-direction: column;
-    gap: 1.2rem;
-    margin-bottom: 2rem;
-  }
-  .planning-table {
+  .planning-table thead {
     display: none;
   }
-}
-
-.stars.editable .star {
-  cursor: pointer;
+  .planning-table,
+  .planning-table tbody,
+  .planning-table tr,
+  .planning-table td {
+    display: block;
+    width: 100%;
+  }
+  .planning-table tr {
+    margin-bottom: 1rem;
+  }
+  .planning-table td {
+    box-sizing: border-box;
+    padding: 0.75rem;
+    border-bottom: 1px solid #f0f0f0;
+  }
+  .planning-table td[data-label] {
+    display: flex;
+    justify-content: space-between;
+  }
+  .planning-table td[data-label]::before {
+    content: attr(data-label);
+    font-weight: 600;
+    color: #555;
+    margin-right: 1rem;
+  }
+  .planning-table td:last-child {
+    border-bottom: none;
+  }
 }
 
 @media (min-width: 900px) {
@@ -466,45 +420,6 @@ body {
   }
 }
 
-.area-header {
-  font-size: 1.2em;
-  font-weight: bold;
-  margin-top: 2rem;
-  color: #0077cc;
-  letter-spacing: 0.03em;
-}
-.day-header {
-  font-size: 1em;
-  font-weight: 600;
-  margin: 1.2rem 0 0.5rem 0.5rem;
-  color: #555;
-}
-.stop-card .stop-header {
-  display: flex;
-  align-items: center;
-  gap: 0.7em;
-  margin-bottom: 0.2em;
-}
-.stop-type {
-  background: #f7fafc;
-  color: #0077cc;
-  border-radius: 1em;
-  padding: 0.1em 0.7em;
-  font-size: 0.85em;
-  margin-left: auto;
-}
-.current-badge {
-  background: #3182bd;
-  color: #fff;
-  border-radius: 1em;
-  padding: 0.1em 0.7em;
-  font-size: 0.85em;
-  margin-left: 0.5em;
-}
-.current-stop {
-  border-left: 3px solid #3182bd !important;
-  box-shadow: 0 0 0 2px #3182bd22;
-}
 .area-header-table {
   background: #eaf6fb;
   color: #0077cc;

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -56,7 +56,6 @@
       </label>
     </div>
     <div id="planning-summary" class="planning-summary"></div>
-    <div id="planning-list" class="mobile-cards"></div>
     <table id="planning-table" class="planning-table"></table>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- remove mobile-only card layout to rely solely on planning table
- make planning table responsive with data-label attributes and CSS
- drop duplicate card rendering code

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68af623eb990832b8c99f0190eac3e2a