### PR TITLE
fix: delay drag start on touch

### DIFF
--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -695,6 +695,10 @@ function initTableDragAndDrop() {
     animation: 150,
     filter: '.day-header-row,.current-stop-row',
     draggable: '.sortable-stop-row',
+    // Delay drag start on touch devices so the page can scroll normally
+    delay: 200,
+    delayOnTouchOnly: true,
+    touchStartThreshold: 10,
     onEnd: async function (evt) {
       // Walk through all rows, updating data-day for each stop row to match the most recent day header above it
       const rows = Array.from(tbody.querySelectorAll('tr'));


### PR DESCRIPTION
## Summary
- allow scrolling without triggering drag on touch

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68af6a6d67c0832b842ba37e0f4cae53