### PR TITLE
feat: track diesel usage and range

### DIFF
--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -100,6 +100,7 @@
     <button id="show-last-trip-btn">Show Current/Last Trip</button>
     <button id="show-all-logs-btn">Show All Logs</button>
   </div>
+  <div id="diesel-info" style="margin-bottom:1em;"></div>
   <div id="log-summary" style="margin-bottom:1em;"></div>
   <div id="broken-items" style="margin-bottom:1em;"></div>
   <div id="log-list"></div>


### PR DESCRIPTION
## Summary
- add diesel info panel showing last fill, economy, diesel burnt/left, and range
- compute fuel stats assuming 140L tank and reset efficiency at each refuel
- remove outdated diesel totals from log summary

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b11e2788832b8fa263c04c7fe5c3