### PR TITLE
Add diesel gauge info panel

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -694,3 +694,48 @@ body {
     flex: 1 1 350px;
   }
 }
+
+/* Diesel gauge styles */
+.diesel-gauge-container {
+  position: relative;
+  width: 200px;
+  margin-bottom: 1rem;
+}
+
+.diesel-gauge {
+  width: 100%;
+  height: auto;
+}
+
+.gauge-bg {
+  fill: none;
+  stroke: #ddd;
+  stroke-width: 10;
+}
+
+.gauge-fill {
+  fill: none;
+  stroke: #4caf50;
+  stroke-width: 10;
+  stroke-linecap: round;
+}
+
+.gauge-needle {
+  stroke: #ff4136;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.gauge-label {
+  font-size: 10px;
+  fill: #333;
+}
+
+.gauge-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -10%);
+  font-weight: bold;
+  font-size: 0.9rem;
+}

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1156,15 +1156,28 @@ function renderDieselInfo(logs = []) {
     return;
   }
 
+  const pct = fuelRemaining / TANK_CAPACITY;
+  const angle = pct * 180 - 90; // -90 is empty, +90 is full
+  const arcTotal = 126; // approximate path length of the semicircle
+  const arcLen = pct * arcTotal;
+
   div.innerHTML = `
     <h4>Diesel</h4>
+    <div class="diesel-gauge-container">
+      <svg viewBox="0 0 100 60" class="diesel-gauge">
+        <path class="gauge-bg" d="M10 50 a40 40 0 0 1 80 0" />
+        <path class="gauge-fill" d="M10 50 a40 40 0 0 1 80 0" style="stroke-dasharray:${arcLen.toFixed(1)} ${arcTotal}" />
+        <line class="gauge-needle" x1="50" y1="50" x2="50" y2="15" transform="rotate(${angle} 50 50)" />
+        <text x="10" y="58" class="gauge-label">E</text>
+        <text x="90" y="58" text-anchor="end" class="gauge-label">F</text>
+      </svg>
+      <div class="gauge-center">${fuelRemaining.toFixed(1)}L</div>
+    </div>
     <ul>
       <li>Last fill: ${
         lastFill
           ? new Date(lastFill.timestamp).toLocaleDateString() +
-            (lastFill.litres != null
-              ? ` (${lastFill.litres} litres)`
-              : "")
+            (lastFill.litres != null ? ` (${lastFill.litres} litres)` : "")
           : "N/A"
       }</li>
       <li>Fuel economy: ${lastEfficiency.toFixed(2)} NM/litre</li>


### PR DESCRIPTION
## Summary
- add SVG-based diesel gauge to log tab for fuel levels
- style new gauge component for instrument-like display

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b89f31d0832bbcbb580a2cabc282