### PR TITLE
Hide distance and ETA columns for current stop

### DIFF
--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -634,9 +634,7 @@ function renderTable(stops, speed) {
       <td>${current.name} <span class="current-badge-table">Current</span></td>
       <td>${labels}</td>
       <td>${stars}</td>
-      <td data-label="Distance (NM)"></td>
-      <td data-label="ETA"></td>
-      <td>${links}</td>
+      <td colspan="3" data-label="Links">${links}</td>
     `;
     tbody.appendChild(tr);
   }


### PR DESCRIPTION
## Summary
- Avoid rendering Distance and ETA columns for the current stop in the planning table

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0baf058e0832b88a11a87320e056b