### PR TITLE
Remove Links label from current stop row

### DIFF
--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -634,7 +634,7 @@ function renderTable(stops, speed) {
       <td>${current.name} <span class="current-badge-table">Current</span></td>
       <td>${labels}</td>
       <td>${stars}</td>
-      <td colspan="3" data-label="Links">${links}</td>
+      <td colspan="3">${links}</td>
     `;
     tbody.appendChild(tr);
   }


### PR DESCRIPTION
## Summary
- hide "Links" label from the current stop row so only icons show

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bd4b22d4832b9e425140d932bc20