### PR TITLE
feat: centralize Trello label colors

### DIFF
--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1,4 +1,9 @@
 // public/js/captains-log.js
+/* eslint-env browser */
+/* global L, Sortable */
+
+const TRELLO_LABEL_COLORS =
+  (typeof window !== "undefined" && window.TRELLO_LABEL_COLORS) || {};
 
 let leafletMap = null;
 
@@ -103,16 +108,6 @@ function getMarkerColor(r, labels = []) {
     (l) => l.name && l.name.toLowerCase() === "visited",
   );
   return hasVisited ? "#555555" : "#d3d3d3"; // dark grey if visited, else light grey
-}
-
-// pick legible text color for a background
-function badgeTextColor(bg) {
-  const hex = bg.replace("#", "");
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return luminance > 0.6 ? "#000" : "#fff";
 }
 
 // build star rating markup
@@ -622,9 +617,12 @@ function renderTable(stops, speed) {
     const labels = Array.isArray(current.labels)
       ? current.labels
           .map((l) => {
-            const bg = l.color || "#888";
-            const fg = badgeTextColor(bg);
-            return `<span class="label" style="background:${bg};color:${fg}">${l.name}</span>`;
+            const c =
+              TRELLO_LABEL_COLORS[l.color] || {
+                background: "#888",
+                foreground: "#fff",
+              };
+            return `<span class="label" style="background:${c.background};color:${c.foreground}">${l.name}</span>`;
           })
           .join("")
       : "";
@@ -750,9 +748,12 @@ function renderTable(stops, speed) {
           ? `<div class="labels-wrap">` +
             s.labels
               .map((l) => {
-                const bg = l.color || "#888";
-                const fg = badgeTextColor(bg);
-                return `<span class="label" style="background:${bg};color:${fg}">${l.name}</span>`;
+                const c =
+                  TRELLO_LABEL_COLORS[l.color] || {
+                    background: "#888",
+                    foreground: "#fff",
+                  };
+                return `<span class="label" style="background:${c.background};color:${c.foreground}">${l.name}</span>`;
               })
               .join("") +
             `</div>`

--- a/routes/captainsLog.js
+++ b/routes/captainsLog.js
@@ -6,6 +6,7 @@ const {
   fetchAllComments,
   fetchBoardWithAllComments,
 } = require("../services/trello");
+const { TRELLO_LABEL_COLORS } = require("../src/trelloColors");
 
 function extractTimestamp(text, fallback, cardId) {
   const match = text.match(/timestamp:\s*([0-9T:\- ]+)/i);
@@ -60,19 +61,6 @@ router.get("/api/data", async (req, res, next) => {
     // map of list IDs → names
     const listNames = Object.fromEntries(lists.map((l) => [l.id, l.name]));
 
-    const colorMap = {
-      green: "#61bd4f",
-      yellow: "#f2d600",
-      orange: "#ff9f1a",
-      red: "#eb5a46",
-      purple: "#c377e0",
-      blue: "#0079bf",
-      sky: "#00c2e0",
-      lime: "#51e898",
-      pink: "#ff78cb",
-      black: "#344563",
-    };
-
     const stops = cards
       .filter((c) => c.due && c.idList !== tripsListId)
       .map((c) => {
@@ -82,7 +70,7 @@ router.get("/api/data", async (req, res, next) => {
 
         const labels = (c.labels || []).map((l) => ({
           name: l.name,
-          color: colorMap[l.color] || "#888",
+          color: l.color,
         }));
 
         return {
@@ -114,7 +102,7 @@ router.get("/api/data", async (req, res, next) => {
         const ratingText = getCFTextOrDropdown(c, customFields, "⭐️");
         const labels = (c.labels || []).map((l) => ({
           name: l.name,
-          color: colorMap[l.color] || "#888",
+          color: l.color,
         }));
         return {
           id: c.id,
@@ -348,7 +336,18 @@ router.get("/captains-log", async (req, res, next) => {
       .map(([year, arr]) => ({ year, trips: arr }))
       .sort((a, b) => b.year.localeCompare(a.year));
 
-    res.render("captains-log", { planningStops, historical, user: req.user });
+    console.log("Planning stops:", planningStops.length);
+    console.log(
+      "Available Trello label colors:",
+      Object.keys(TRELLO_LABEL_COLORS),
+    );
+
+    res.render("captains-log", {
+      planningStops,
+      historical,
+      user: req.user,
+      trelloColors: TRELLO_LABEL_COLORS,
+    });
   } catch (err) {
     next(err);
   }

--- a/src/trelloColors.js
+++ b/src/trelloColors.js
@@ -1,0 +1,14 @@
+const TRELLO_LABEL_COLORS = {
+  green:  { background: '#61BD4F', foreground: '#FFFFFF' },
+  yellow: { background: '#F2D600', foreground: '#000000' },
+  orange: { background: '#FF9F1A', foreground: '#FFFFFF' },
+  red:    { background: '#EB5A46', foreground: '#FFFFFF' },
+  purple: { background: '#C377E0', foreground: '#FFFFFF' },
+  blue:   { background: '#0079BF', foreground: '#FFFFFF' },
+  sky:    { background: '#00C2E0', foreground: '#FFFFFF' },
+  lime:   { background: '#51E898', foreground: '#000000' },
+  pink:   { background: '#FF78CB', foreground: '#FFFFFF' },
+  black:  { background: '#344563', foreground: '#FFFFFF' }
+};
+
+module.exports = { TRELLO_LABEL_COLORS };

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -114,5 +114,10 @@
 <!-– Sortable core ––>
 <script src="https://unpkg.com/sortablejs@1.15.2/Sortable.min.js"></script>
 
+<!–– Trello label colors available globally ––>
+<script>
+  window.TRELLO_LABEL_COLORS = <%- JSON.stringify(trelloColors) %>;
+</script>
+
 <!–– Your app JS ––>
 <script src="/js/captains-log.js"></script>


### PR DESCRIPTION
## Summary
- add shared Trello label colour map
- expose palette to client and render labels with foreground/background
- safeguard client rendering when palette missing and log palette usage on server

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c0ae0218832ba7f49b9879f9520a