### PR TITLE
Add underway status based on recent comments

### DIFF
--- a/services/trello.js
+++ b/services/trello.js
@@ -13,6 +13,15 @@ async function fetchBoard() {
   return data;
 }
 
+// Fetch a limited number of recent comments (actions)
+async function fetchRecentComments(limit = 100) {
+  const url =
+    BASE_URL +
+    `/actions?filter=commentCard&limit=${limit}&key=${KEY}&token=${TOKEN}`;
+  const { data } = await axios.get(url);
+  return data;
+}
+
 async function fetchAllComments() {
   let allActions = [];
   let before = null;
@@ -39,4 +48,9 @@ async function fetchBoardWithAllComments() {
   return board;
 }
 
-module.exports = { fetchBoard, fetchAllComments, fetchBoardWithAllComments };
+module.exports = {
+  fetchBoard,
+  fetchAllComments,
+  fetchBoardWithAllComments,
+  fetchRecentComments,
+};


### PR DESCRIPTION
## Summary
- add Trello helper to fetch a limited number of recent comments
- create `/api/current-stop` route to derive current location or underway status from recent comments and planned stops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1f3dd7230832bbcb45a5579bbe4d9