### PR TITLE
Use comment logs to show current or underway status

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -512,6 +512,10 @@ body {
   filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.18));
 }
 
+.map-current-marker {
+  filter: drop-shadow(0 0 6px #0077cc);
+}
+
 .stars.editable .star {
   cursor: pointer;
 }

--- a/routes/captainsLog.js
+++ b/routes/captainsLog.js
@@ -46,6 +46,19 @@ function getCFTextOrDropdown(card, boardCFs, name) {
   return null;
 }
 
+const colorMap = {
+  green: "#61bd4f",
+  yellow: "#f2d600",
+  orange: "#ff9f1a",
+  red: "#eb5a46",
+  purple: "#c377e0",
+  blue: "#0079bf",
+  sky: "#00c2e0",
+  lime: "#51e898",
+  pink: "#ff78cb",
+  black: "#344563",
+};
+
 router.get("/api/data", async (req, res, next) => {
   try {
     const { cards, lists, customFields, members } = await fetchBoard();
@@ -60,19 +73,6 @@ router.get("/api/data", async (req, res, next) => {
 
     // map of list IDs → names
     const listNames = Object.fromEntries(lists.map((l) => [l.id, l.name]));
-
-    const colorMap = {
-      green: "#61bd4f",
-      yellow: "#f2d600",
-      orange: "#ff9f1a",
-      red: "#eb5a46",
-      purple: "#c377e0",
-      blue: "#0079bf",
-      sky: "#00c2e0",
-      lime: "#51e898",
-      pink: "#ff78cb",
-      black: "#344563",
-    };
 
     const stops = cards
       .filter((c) => c.due && c.idList !== tripsListId)
@@ -326,6 +326,12 @@ router.get("/api/current-stop", async (req, res, next) => {
 
     function buildStop(card) {
       if (!card) return null;
+      const ratingText = getCFTextOrDropdown(card, customFields, "⭐️");
+      const ratingNum = ratingText != null ? parseInt(ratingText, 10) : null;
+      const labels = (card.labels || []).map((l) => ({
+        name: l.name,
+        color: colorMap[l.color] || "#888",
+      }));
       return {
         id: card.id,
         name: card.name,
@@ -334,6 +340,9 @@ router.get("/api/current-stop", async (req, res, next) => {
         lat: getCFNumber(card, customFields, "Latitude"),
         lng: getCFNumber(card, customFields, "Longitude"),
         trelloUrl: card.shortUrl,
+        navilyUrl: getCFTextOrDropdown(card, customFields, "Navily"),
+        rating: ratingNum,
+        labels,
       };
     }
 


### PR DESCRIPTION
## Summary
- Determine current status via `/api/current-stop` instead of Trello `dueComplete`
- Display "Current" stop from latest arrival or an "Underway" banner when most recent departure is newer
- Update total-distance summary and data refreshes to respect the new status API
- Include labels, ratings, and Navily links for current or departed stops and highlight the last stop on the map

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b20124f448832b923e04b1286671ff