### PR TITLE
Show expected position while underway

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -323,6 +323,26 @@ body {
   margin-left: 0.5em;
 }
 
+.current-badge-table.underway-badge {
+  background: #ff9800;
+  animation: pulse 1s ease-in-out infinite;
+}
+.current-badge-table.underway-badge::after {
+  content: " \26F5"; /* sailboat emoji */
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
 .day-header-row,
 .area-header-table {
   background: #eaf6fb;
@@ -514,6 +534,10 @@ body {
 
 .map-current-marker {
   filter: drop-shadow(0 0 6px #0077cc);
+}
+
+.underway-marker {
+  font-size: 24px;
 }
 
 .stars.editable .star {

--- a/routes/captainsLog.js
+++ b/routes/captainsLog.js
@@ -379,6 +379,7 @@ router.get("/api/current-stop", async (req, res, next) => {
         cards.find((c) => c.id === lastDeparted.data.card.id),
       );
       result.destination = plannedDestination;
+      result.departedAt = lastDeparted.ts;
     } else if (lastArrived) {
       result.status = "arrived";
       result.current = buildStop(


### PR DESCRIPTION
## Summary
- include departure timestamp in current-stop API
- compute expected position from departure time and speed and show on map
- highlight underway status with animated badge

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b20f15a3c0832b8d54427cb52d80c5