### PR TITLE
feat: group planned stops by day

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -232,7 +232,7 @@ body {
   border-radius: 0.25rem;
   font-size: 0.7rem;
   margin-bottom: 0.2em;
-  margin-right: 0.5em;      /* Add this for extra horizontal space */
+  margin-right: 0.5em; /* Add this for extra horizontal space */
   white-space: nowrap; /* Prevent label text from breaking inside the label */
 }
 .rating {
@@ -268,10 +268,10 @@ body {
 }
 
 .planning-table tr {
-  margin-bottom: 1.2em;
+  margin-bottom: 0;
   background: #fff;
-  border-radius: 0.5em;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+  border-radius: 0;
+  box-shadow: none;
   padding: 0.5em 0;
 }
 
@@ -343,7 +343,20 @@ body {
   }
 }
 
-.day-header-row,
+.day-header-row {
+  background: #eaf6fb;
+  color: #0077cc;
+  font-weight: bold;
+  font-size: 1.1em;
+  letter-spacing: 0.03em;
+  padding-top: 1.2em;
+  border: 1px solid #e0e0e0;
+  border-bottom: none;
+  border-radius: 0.5em 0.5em 0 0;
+  margin-top: 1rem;
+  display: block;
+}
+
 .area-header-table {
   background: #eaf6fb;
   color: #0077cc;
@@ -355,6 +368,19 @@ body {
   border-radius: 0.5em 0.5em 0 0;
   margin-bottom: 0.5em;
   display: block;
+}
+
+.planning-table tr[data-day]:not(.day-header-row) {
+  border-left: 1px solid #e0e0e0;
+  border-right: 1px solid #e0e0e0;
+}
+
+.planning-table tr.day-end-row {
+  border-left: 1px solid #e0e0e0;
+  border-right: 1px solid #e0e0e0;
+  border-bottom: 1px solid #e0e0e0;
+  border-radius: 0 0 0.5em 0.5em;
+  margin-bottom: 1rem;
 }
 
 .day-header-table {
@@ -543,8 +569,6 @@ body {
 .stars.editable .star {
   cursor: pointer;
 }
-
-
 
 .area-header-table {
   background: #eaf6fb;

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -92,9 +92,12 @@ function updateSummary(stops, speed) {
   let prev = null;
   if (currentStatus) {
     if (currentStatus.status === "arrived" && currentStatus.current) {
-      prev = stops.find((s) => s.id === currentStatus.current.id) || currentStatus.current;
+      prev =
+        stops.find((s) => s.id === currentStatus.current.id) ||
+        currentStatus.current;
     } else if (currentStatus.status === "underway" && currentStatus.from) {
-      prev = stops.find((s) => s.id === currentStatus.from.id) || currentStatus.from;
+      prev =
+        stops.find((s) => s.id === currentStatus.from.id) || currentStatus.from;
     }
   } else {
     prev = stops.find((s) => s.dueComplete) || null;
@@ -475,7 +478,8 @@ function initMap(stops, places, logs = null) {
       currentStatus.destination &&
       currentStatus.departedAt
     ) {
-      const speed = parseFloat(document.getElementById("speed-input").value) || 0;
+      const speed =
+        parseFloat(document.getElementById("speed-input").value) || 0;
       if (speed > 0) {
         const pos = getExpectedPosition(
           currentStatus.from,
@@ -581,7 +585,7 @@ function initMap(stops, places, logs = null) {
     if (canPlan) {
       const container = e.popup._contentNode.querySelector(".stars.editable");
       if (container) {
-        container.querySelectorAll(".star").forEach(star => {
+        container.querySelectorAll(".star").forEach((star) => {
           star.addEventListener("click", async (ev) => {
             ev.stopPropagation();
             const rating = parseInt(star.getAttribute("data-value"), 10);
@@ -592,7 +596,7 @@ function initMap(stops, places, logs = null) {
               body: JSON.stringify({ cardId, rating }),
             });
             if (res.ok) {
-              container.querySelectorAll(".star").forEach(s => {
+              container.querySelectorAll(".star").forEach((s) => {
                 const val = parseInt(s.getAttribute("data-value"), 10);
                 s.textContent = val <= rating ? "★" : "☆";
               });
@@ -830,6 +834,7 @@ function renderTable(stops, speed) {
       let dayTotalNM = 0,
         dayTotalH = 0;
       let dayPrev = prevStop;
+      const dayRows = [];
       stopsForDay.forEach((s) => {
         if (dayPrev) {
           const [lat1, lng1] = getLatLng(dayPrev);
@@ -849,7 +854,10 @@ function renderTable(stops, speed) {
         dayPrev = s;
       });
 
-      let dayTotalNMValue =  dayTotalNM >= 1 ? Math.round(dayTotalNM).toString() : dayTotalNM.toFixed(1);
+      let dayTotalNMValue =
+        dayTotalNM >= 1
+          ? Math.round(dayTotalNM).toString()
+          : dayTotalNM.toFixed(1);
 
       const dayRow = document.createElement("tr");
       dayRow.className = "day-header-row";
@@ -862,6 +870,7 @@ function renderTable(stops, speed) {
         </span>
       </td>`;
       tbody.appendChild(dayRow);
+      dayRows.push(dayRow);
 
       // Sort stops by time
       stopsForDay.sort((a, b) => new Date(a.due) - new Date(b.due));
@@ -881,7 +890,10 @@ function renderTable(stops, speed) {
           ) {
             const meters = haversine(lat1, lng1, lat2, lng2);
             let nmValue = toNM(meters);
-            nm = nmValue >= 1 ? Math.round(nmValue).toString() : nmValue.toFixed(1);
+            nm =
+              nmValue >= 1
+                ? Math.round(nmValue).toString()
+                : nmValue.toFixed(1);
             eta = formatDurationRounded(nm / speed);
           }
         }
@@ -932,6 +944,7 @@ function renderTable(stops, speed) {
           <td>${links}</td>
         `;
         tbody.appendChild(tr);
+        dayRows.push(tr);
         prevStop = s;
       });
 
@@ -942,11 +955,15 @@ function renderTable(stops, speed) {
         tr.setAttribute("data-day", dayKey);
         tr.innerHTML = `<td colspan="6" style="text-align:center; color:#bbb; font-style:italic;">No plans...</td>`;
         tbody.appendChild(tr);
+        dayRows.push(tr);
       }
+
+      const lastRow = dayRows[dayRows.length - 1];
+      if (lastRow) lastRow.classList.add("day-end-row");
     }
     if (canPlan) {
-      document.querySelectorAll(".stars.editable").forEach(container => {
-        container.querySelectorAll(".star").forEach(star => {
+      document.querySelectorAll(".stars.editable").forEach((container) => {
+        container.querySelectorAll(".star").forEach((star) => {
           star.addEventListener("click", async (e) => {
             e.stopPropagation();
             const rating = parseInt(star.getAttribute("data-value"), 10);
@@ -957,7 +974,7 @@ function renderTable(stops, speed) {
               body: JSON.stringify({ cardId, rating }),
             });
             if (res.ok) {
-              container.querySelectorAll(".star").forEach(s => {
+              container.querySelectorAll(".star").forEach((s) => {
                 const val = parseInt(s.getAttribute("data-value"), 10);
                 s.textContent = val <= rating ? "★" : "☆";
               });
@@ -1192,7 +1209,6 @@ function renderLogSummary(logs = []) {
       if (isFinite(hrs)) totalHrs += hrs;
       lastDepart = null;
     }
-
   });
 
   const latest = (type) =>
@@ -1310,8 +1326,7 @@ function renderDieselInfo(logs = []) {
   const range = lastEfficiency ? fuelRemaining * lastEfficiency : null;
 
   if (!lastEfficiency) {
-    div.innerHTML =
-      "<h4>Diesel</h4><p>Not enough data to estimate usage.</p>";
+    div.innerHTML = "<h4>Diesel</h4><p>Not enough data to estimate usage.</p>";
     return;
   }
 


### PR DESCRIPTION
## Summary
- highlight each day in the planning table with a bordered block
- add spacing between day sections and mark last row of each day

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b292308d70832bbd493971f315ee55