### PR TITLE
style: enhance broken items display

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -791,3 +791,55 @@ body {
   font-weight: bold;
   font-size: 0.9rem;
 }
+
+/* Broken items styles */
+#broken-items {
+  background: #fff;
+  padding: 1em;
+  border-radius: 0.5em;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  margin-bottom: 1em;
+}
+
+#broken-items h4 {
+  margin-top: 0;
+  font-size: 1.2em;
+}
+
+.broken-items-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+
+.broken-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6em 0.8em;
+  background: #f7fafc;
+  border-radius: 0.5em;
+}
+
+.broken-item .status {
+  font-size: 0.85em;
+  font-weight: 600;
+  padding: 0.2em 0.7em;
+  border-radius: 1em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+}
+
+.broken-item .status.broken {
+  background: #ffeaea;
+  color: #d93025;
+}
+
+.broken-item .status.fixed {
+  background: #e6f4ea;
+  color: #107c10;
+}

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1386,9 +1386,18 @@ function renderBrokenItems(logs = []) {
   }
 
   const list = entries
-    .map((e) => `<li>${e.item}: ${e.fixed ? "Fixed" : "Broken"}</li>`)
+    .map(
+      (e) => `
+      <li class="broken-item">
+        <span class="item-name">${e.item}</span>
+        <span class="status ${e.fixed ? "fixed" : "broken"}">
+          <i class="fa-solid ${e.fixed ? "fa-check" : "fa-circle-xmark"}"></i>
+          ${e.fixed ? "Fixed" : "Broken"}
+        </span>
+      </li>`,
+    )
     .join("");
-  div.innerHTML = `<h4>Broken Items</h4><ul>${list}</ul>`;
+  div.innerHTML = `<h4>Broken Items</h4><ul class="broken-items-list">${list}</ul>`;
 }
 
 // Render historical map (only arrived unique places). Uses window.histMap to cleanup.

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -102,7 +102,7 @@
   </div>
   <div id="diesel-info" style="margin-bottom:1em;"></div>
   <div id="log-summary" style="margin-bottom:1em;"></div>
-  <div id="broken-items" style="margin-bottom:1em;"></div>
+  <div id="broken-items"></div>
   <div id="log-list"></div>
 </section>
 </main>


### PR DESCRIPTION
## Summary
- Style broken items section with card layout and status pills
- Render broken item list with icons for broken/fixed status
- Remove inline styling from broken items container

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b351018e60832b815537c3c508bf39