### PR TITLE
feat: enhance trip summary panel

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -470,9 +470,25 @@ body {
 }
 
 .planning-summary {
-  text-align: right;
-  font-weight: 600;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  justify-content: space-around;
   margin: 0.5rem 0 1rem;
+  padding: 0.5rem 1rem;
+  background: #f0f4f8;
+  border-radius: 0.5rem;
+  font-weight: 600;
+}
+
+.planning-summary .summary-item {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: #333;
+}
+
+.planning-summary .summary-item i {
   color: #0077cc;
 }
 


### PR DESCRIPTION
## Summary
- show total stops, days away, distance, longest stay, and travel time in planning summary
- style planning summary as a highlighted info panel

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b35ae66a64832bbb37f49d1fd77c14