### PR TITLE
Trim planning totals and tidy view

### DIFF
--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -119,35 +119,18 @@ function updateSummary(stops, speed) {
   // --- Additional stats ---
   const totalStops = future.length;
   let totalDays = 0;
-  let longestStay = 0;
-  let longestStayName = null;
   if (future.length > 0) {
     const first = new Date(future[0].due);
     const last = new Date(future[future.length - 1].due);
     totalDays = Math.round((last - first) / 86400000) + 1;
-
-    for (let i = 0; i < future.length - 1; i++) {
-      const cur = new Date(future[i].due);
-      const next = new Date(future[i + 1].due);
-      const stay = (next - cur) / 86400000;
-      if (stay > longestStay) {
-        longestStay = stay;
-        longestStayName = future[i].name;
-      }
-    }
   }
 
   const totalH = totalNM / speed;
-  const longestStayText =
-    longestStayName != null
-      ? `${longestStay.toFixed(1)} days in ${longestStayName}`
-      : "N/A";
 
   summaryEl.innerHTML = `
     <div class="summary-item"><i class="fa-solid fa-location-dot"></i><span>${totalStops} stops</span></div>
     <div class="summary-item"><i class="fa-solid fa-calendar-days"></i><span>${totalDays} days away</span></div>
     <div class="summary-item"><i class="fa-solid fa-route"></i><span>${totalNM.toFixed(1)} NM</span></div>
-    <div class="summary-item"><i class="fa-solid fa-bed"></i><span>Longest stay: ${longestStayText}</span></div>
     <div class="summary-item"><i class="fa-solid fa-clock"></i><span>${formatDurationRounded(totalH)}</span></div>
   `;
 }

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -34,7 +34,7 @@
 
 <div class="tab-nav">
   <button data-tab="planning" class="active">Planning</button>
-  <button data-tab="historical">Historical Trips</button>
+  <button data-tab="historical">Trips</button>
   <button data-tab="log">Log</button>
 </div>
 
@@ -62,7 +62,7 @@
       <div id="planning-summary" class="summary-panel"></div>
       <table id="planning-table" class="planning-table"></table>
     </div>
-  </div>>
+  </div>
 </section>
 
 <section id="historical" class="tab-content hidden">


### PR DESCRIPTION
## Summary
- Remove longest stay from planning summary totals
- Fix stray `>` and rename Historical Trips tab to Trips

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fd93d800832b86105c806cbfab00