### PR TITLE
Revamp underway journey display

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -330,6 +330,21 @@ body {
   content: " \26F5"; /* sailboat emoji */
 }
 
+.underway-row {
+  background: #fff3e0;
+  border-left: 4px solid #ff9800;
+}
+
+.underway-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+}
+
+.underway-info .current-badge-table {
+  margin-bottom: 0.3em;
+}
+
 @keyframes pulse {
   0% {
     transform: scale(1);


### PR DESCRIPTION
## Summary
- Overhaul underway table row to emphasize current journey
- Show heading destination, departed time, estimated position, ETA and duration underway
- Style new underway info block with distinct colours

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b401dbc30c832bb2b850d01e70166a