### PR TITLE
Add visited comment type for waypoint tracking

### DIFF
--- a/routes/captainsLog.js
+++ b/routes/captainsLog.js
@@ -207,6 +207,8 @@ router.get("/api/logs", async (req, res, next) => {
           type = "Arrived";
         } else if (/^departed\b/i.test(text)) {
           type = "Departed";
+        } else if (/^visited\b/i.test(text)) {
+          type = "Visited";
         } else if (/^water\b/i.test(text)) {
           type = "Water";
         } else {


### PR DESCRIPTION
## Summary
- recognize `visited` comments on the server and expose them in API logs
- show visited waypoints on planning and history maps
- include visited points in log summaries and diesel calculations

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b42c9f5cc0832bb1183ec166581936