### PR TITLE
Fix log map start leg and show dotted route

### DIFF
--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -424,10 +424,17 @@ function initMap(stops, places, logs = null) {
     if (
       firstDeparted &&
       typeof firstDeparted.lat === "number" &&
-      typeof firstDeparted.lng === "number" &&
-      !seen.has(firstDeparted.cardId)
+      typeof firstDeparted.lng === "number"
     ) {
-      unique.unshift(firstDeparted);
+      const hasCoordsForCard = unique.some(
+        (u) =>
+          u.cardId === firstDeparted.cardId &&
+          typeof u.lat === "number" &&
+          typeof u.lng === "number",
+      );
+      if (!hasCoordsForCard) {
+        unique.unshift(firstDeparted);
+      }
     }
 
     // Plot markers and route
@@ -449,7 +456,7 @@ function initMap(stops, places, logs = null) {
         color: "#888", // lighter gray
         weight: 2,
         opacity: 0.5, // more faint
-        dashArray: "4 6", // dashed line
+        dashArray: "2 8", // dotted line
       }).addTo(logLayerGroup);
     }
     logMarkers.forEach((m) => {


### PR DESCRIPTION
## Summary
- Ensure earliest departed log is prepended when needed so first leg draws on log map
- Render log route with dotted line styling

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*


------
https://chatgpt.com/codex/tasks/task_e_68b49b67b790832bb4deae56850d8621