### PR TITLE
Revamp log view with responsive layout

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -767,6 +767,10 @@ body {
   font-weight: 600;
   color: #0077cc;
 }
+.historical-log-labels {
+  display: flex;
+  flex-wrap: wrap;
+}
 .historical-log-labels .label {
   display: inline-block;
   padding: 0.1em 0.4em;

--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -681,6 +681,40 @@ body {
   background: #005fa3;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 }
+
+/* Layout for log section */
+.log-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+.log-left {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+#log-map {
+  height: 350px;
+  margin-top: 2rem;
+}
+#log-list {
+  overflow-x: auto;
+}
+@media (min-width: 900px) {
+  .log-layout {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+  .log-left {
+    flex: 1 1 50%;
+  }
+  #log-map {
+    height: 60vh;
+  }
+  #log-list {
+    flex: 1 1 50%;
+  }
+}
 .historical-trip-list {
   list-style: none;
   padding: 0;
@@ -712,23 +746,41 @@ body {
   color: #005fa3;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.07);
 }
+.historical-log-header,
 .historical-log-entry {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1.2fr 1fr 0.8fr 1.2fr 0.8fr auto;
+  gap: 0.5em;
   align-items: center;
-  gap: 1em;
   padding: 0.7em 0.5em;
+}
+.historical-log-header {
+  font-weight: 600;
+  background: #f7fafc;
+  border-bottom: 2px solid #e0e0e0;
+}
+.historical-log-entry {
   border-bottom: 1px solid #f0f0f0;
   font-size: 1em;
 }
 .historical-log-place {
   font-weight: 600;
   color: #0077cc;
-  min-width: 120px;
+}
+.historical-log-labels .label {
+  display: inline-block;
+  padding: 0.1em 0.4em;
+  margin: 0 0.2em 0.2em 0;
+  border-radius: 0.3em;
+  font-size: 0.8em;
+}
+.historical-log-distance {
+  color: #555;
+  font-size: 0.9em;
 }
 .historical-log-date {
   color: #555;
   font-size: 0.95em;
-  min-width: 110px;
 }
 .historical-log-rating {
   color: #ffb400;
@@ -738,6 +790,40 @@ body {
   margin-right: 0.5em;
   color: #0077cc;
   font-size: 1.2em;
+}
+
+@media (max-width: 600px) {
+  .historical-log-header {
+    display: none;
+  }
+  .historical-log-entry {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "place rating"
+      "labels labels"
+      "distance date"
+      "links links";
+  }
+  .historical-log-place {
+    grid-area: place;
+  }
+  .historical-log-rating {
+    grid-area: rating;
+    justify-self: end;
+  }
+  .historical-log-labels {
+    grid-area: labels;
+  }
+  .historical-log-distance {
+    grid-area: distance;
+  }
+  .historical-log-date {
+    grid-area: date;
+    justify-self: end;
+  }
+  .historical-log-links {
+    grid-area: links;
+  }
 }
 @media (max-width: 899px) {
   .log-table {

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1835,3 +1835,134 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 });
+// Enhanced log rendering with labels and distance
+renderHistoricalLog = function (logs = [], stops = []) {
+  const section = document.getElementById("log-list");
+  if (!section) return;
+  section.innerHTML = "";
+
+  const chron = logs
+    .filter((l) => l.type === "Arrived" || l.type === "Visited")
+    .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+
+  const firstDeparted = logs
+    .filter((l) => l.type === "Departed")
+    .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp))[0];
+  if (firstDeparted) {
+    chron.unshift(firstDeparted);
+  }
+
+  if (!chron.length) {
+    section.innerHTML = "<p>No visits found.</p>";
+    return;
+  }
+
+  let prev = null;
+  chron.forEach((l) => {
+    let dist = null;
+    if (
+      prev &&
+      prev.lat != null &&
+      prev.lng != null &&
+      l.lat != null &&
+      l.lng != null
+    ) {
+      const meters = haversine(prev.lat, prev.lng, l.lat, l.lng);
+      dist = toNM(meters);
+    }
+    l._distanceNm = dist;
+    prev = l;
+  });
+
+  const header = document.createElement("div");
+  header.className = "historical-log-header";
+  header.innerHTML = `
+    <div>Place</div>
+    <div>Labels</div>
+    <div>Distance</div>
+    <div>Date</div>
+    <div>Rating</div>
+    <div>Links</div>
+  `;
+  section.appendChild(header);
+
+  const displayLogs = [...chron].reverse();
+
+  displayLogs.forEach((l) => {
+    const stop =
+      stops.find((s) => s.id === l.cardId) ||
+      stops.find((s) => s.name === l.cardName);
+    const currentRating = stop ? stop.rating : l.rating;
+    const ratingHtml = canPlan
+      ? makeEditableStars(currentRating, l.cardId)
+      : currentRating != null
+        ? makeStars(currentRating)
+        : "";
+    const navily =
+      stop && stop.navilyUrl
+        ? `<a href="${stop.navilyUrl}" target="_blank" title="Navily"><i class="fa-solid fa-anchor"></i></a>`
+        : l.navilyUrl
+          ? `<a href="${l.navilyUrl}" target="_blank" title="Navily"><i class="fa-solid fa-anchor"></i></a>`
+          : "";
+    const trello = l.trelloUrl
+      ? `<a href="${l.trelloUrl}" target="_blank" title="Trello"><i class="fab fa-trello"></i></a>`
+      : "";
+    const labelsHtml =
+      stop && Array.isArray(stop.labels)
+        ? stop.labels
+            .map((lab) => {
+              const bg = lab.color || "#888";
+              const fg = badgeTextColor(bg);
+              return `<span class="label" style="background:${bg};color:${fg}">${lab.name}</span>`;
+            })
+            .join("")
+        : "";
+    const distHtml =
+      l._distanceNm != null ? `${l._distanceNm.toFixed(1)} NM` : "";
+
+    const div = document.createElement("div");
+    div.className = "historical-log-entry";
+    div.innerHTML = `
+      <div class="historical-log-place">${l.cardName}</div>
+      <div class="historical-log-labels">${labelsHtml}</div>
+      <div class="historical-log-distance">${distHtml}</div>
+      <div class="historical-log-date">${new Date(l.timestamp).toLocaleDateString()} ${new Date(l.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</div>
+      <div class="historical-log-rating">${ratingHtml}</div>
+      <div class="historical-log-links">${navily}${trello}</div>
+    `;
+    section.appendChild(div);
+
+    if (canPlan) {
+      const container = div.querySelector(".stars.editable");
+      if (container) {
+        container.querySelectorAll(".star").forEach((star) => {
+          star.addEventListener("click", async (e) => {
+            e.stopPropagation();
+            const rating = parseInt(star.getAttribute("data-value"), 10);
+            const cardId = container.getAttribute("data-card-id");
+            const res = await fetch("/api/rate-place", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ cardId, rating }),
+            });
+            if (res.ok) {
+              container.querySelectorAll(".star").forEach((s) => {
+                const val = parseInt(s.getAttribute("data-value"), 10);
+                s.textContent = val <= rating ? "★" : "☆";
+              });
+              const stop = stops.find((s) => s.id === cardId);
+              if (stop) stop.rating = rating;
+              if (lastLoadedLogs) {
+                lastLoadedLogs.forEach((log) => {
+                  if (log.cardId === cardId) log.rating = rating;
+                });
+              }
+            } else {
+              alert("Failed to save rating");
+            }
+          });
+        });
+      }
+    }
+  });
+};

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1907,18 +1907,28 @@ renderHistoricalLog = function (logs = [], stops = []) {
     const trello = l.trelloUrl
       ? `<a href="${l.trelloUrl}" target="_blank" title="Trello"><i class="fab fa-trello"></i></a>`
       : "";
-    const labelsHtml =
+    const labelsArr =
       stop && Array.isArray(stop.labels)
         ? stop.labels
-            .map((lab) => {
-              const bg = lab.color || "#888";
-              const fg = badgeTextColor(bg);
-              return `<span class="label" style="background:${bg};color:${fg}">${lab.name}</span>`;
-            })
-            .join("")
-        : "";
+        : Array.isArray(l.labels)
+          ? l.labels
+          : [];
+    const labelsHtml = labelsArr
+      .map((lab) => {
+        const bg = lab.color || "#888";
+        const fg = badgeTextColor(bg);
+        return `<span class="label" style="background:${bg};color:${fg}">${lab.name}</span>`;
+      })
+      .join("");
     const distHtml =
       l._distanceNm != null ? `${l._distanceNm.toFixed(1)} NM` : "";
+    const dateStr = new Date(l.timestamp).toLocaleString([], {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
 
     const div = document.createElement("div");
     div.className = "historical-log-entry";
@@ -1926,7 +1936,7 @@ renderHistoricalLog = function (logs = [], stops = []) {
       <div class="historical-log-place">${l.cardName}</div>
       <div class="historical-log-labels">${labelsHtml}</div>
       <div class="historical-log-distance">${distHtml}</div>
-      <div class="historical-log-date">${new Date(l.timestamp).toLocaleDateString()} ${new Date(l.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</div>
+      <div class="historical-log-date">${dateStr}</div>
       <div class="historical-log-rating">${ratingHtml}</div>
       <div class="historical-log-links">${navily}${trello}</div>
     `;

--- a/routes/captainsLog.js
+++ b/routes/captainsLog.js
@@ -250,11 +250,18 @@ router.get("/api/logs", async (req, res, next) => {
         if (!type) return null;
         const card = cards.find((c) => c.id === a.data.card.id);
         const timestamp = extractTimestamp(text, a.date, a.data.card.id);
+        const labels = card
+          ? (card.labels || []).map((l) => ({
+              name: l.name,
+              color: colorMap[l.color] || "#888",
+            }))
+          : [];
         return {
           area: card && card.idList ? listNames[card.idList] : "Unknown",
           cardName: card ? card.name : a.data.card.name || "Unknown",
           type,
           timestamp,
+          labels,
           comment: text,
           cardId: a.data.card.id,
           trelloUrl: card ? card.shortUrl : undefined,
@@ -280,7 +287,7 @@ router.get("/api/logs", async (req, res, next) => {
       })
       .filter(Boolean);
 
-    let filteredLogs = logs; // <--- ADD THIS LINE
+    let filteredLogs = logs;
 
     // If trip=all, return all logs
     if (req.query.trip === "all") {

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -95,15 +95,19 @@
 </section>
 
 <section id="log" class="tab-content hidden">
-  <div id="log-map" style="height: 350px; margin-top: 2rem;"></div>
-  <div id="log-controls" style="margin-bottom:1em;">
-    <button id="show-last-trip-btn">Show Current/Last Trip</button>
-    <button id="show-all-logs-btn">Show All Logs</button>
+  <div class="log-layout">
+    <div class="log-left">
+      <div id="log-map"></div>
+      <div id="log-controls">
+        <button id="show-last-trip-btn">Show Current/Last Trip</button>
+        <button id="show-all-logs-btn">Show All Logs</button>
+      </div>
+      <div id="diesel-info"></div>
+      <div id="log-summary" class="summary-panel"></div>
+      <div id="broken-items"></div>
+    </div>
+    <div id="log-list"></div>
   </div>
-  <div id="diesel-info" style="margin-bottom:1em;"></div>
-  <div id="log-summary" class="summary-panel" style="margin-bottom:1em;"></div>
-  <div id="broken-items"></div>
-  <div id="log-list"></div>
 </section>
 </main>
 

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -102,8 +102,8 @@
         <button id="show-last-trip-btn">Show Current/Last Trip</button>
         <button id="show-all-logs-btn">Show All Logs</button>
       </div>
-      <div id="diesel-info"></div>
       <div id="log-summary" class="summary-panel"></div>
+      <div id="diesel-info"></div>
       <div id="broken-items"></div>
     </div>
     <div id="log-list"></div>


### PR DESCRIPTION
## Summary
- Restructure log section with flexible layout and map/list columns
- Style log entries with labels, ratings, distance info and mobile-friendly grid
- Enhance historical log renderer to include labels and leg distances

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b52fdd8b08832b812465534c314a92