### PR TITLE
Refine log view data formatting

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -789,6 +789,7 @@ body {
 .historical-log-rating {
   color: #ffb400;
   font-size: 1.2em;
+  letter-spacing: 0.1em;
 }
 .historical-log-links a {
   margin-right: 0.5em;

--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -699,6 +699,14 @@ body {
 }
 #log-list {
   overflow-x: auto;
+  background: #fff;
+  padding: 1em;
+  border-radius: 0.5em;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  margin-bottom: 1em;
 }
 @media (min-width: 900px) {
   .log-layout {
@@ -752,15 +760,14 @@ body {
   grid-template-columns: 1.2fr 1fr 0.8fr 1.2fr 0.8fr auto;
   gap: 0.5em;
   align-items: center;
-  padding: 0.7em 0.5em;
+  padding: 0.6em 0.8em;
+  background: #f7fafc;
+  border-radius: 0.5em;
 }
 .historical-log-header {
   font-weight: 600;
-  background: #f7fafc;
-  border-bottom: 2px solid #e0e0e0;
 }
 .historical-log-entry {
-  border-bottom: 1px solid #f0f0f0;
   font-size: 1em;
 }
 .historical-log-place {

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1914,15 +1914,30 @@ renderHistoricalLog = function (logs = [], stops = []) {
           ? l.labels
           : [];
     const labelsHtml = labelsArr
+      .filter((lab) => lab.name && lab.name.toLowerCase() !== "visited")
       .map((lab) => {
         const bg = lab.color || "#888";
         const fg = badgeTextColor(bg);
         return `<span class="label" style="background:${bg};color:${fg}">${lab.name}</span>`;
       })
       .join("");
-    const distHtml =
-      l._distanceNm != null ? `${l._distanceNm.toFixed(1)} NM` : "";
-    const dateStr = new Date(l.timestamp).toLocaleString([], {
+
+    let distHtml = "";
+    if (l._distanceNm != null) {
+      let rounded;
+      if (l._distanceNm < 1) {
+        rounded = l._distanceNm < 0.75 ? 0.5 : 1;
+      } else {
+        rounded = Math.round(l._distanceNm);
+      }
+      const display =
+        rounded % 1 === 0 ? rounded.toFixed(0) : rounded.toFixed(1);
+      distHtml = `${display} NM`;
+    }
+    const d = new Date(l.timestamp);
+    const ms = 30 * 60 * 1000; // 30 minutes in ms
+    const roundedDate = new Date(Math.round(d.getTime() / ms) * ms);
+    const dateStr = roundedDate.toLocaleString([], {
       year: "numeric",
       month: "short",
       day: "numeric",


### PR DESCRIPTION
## Summary
- Hide "Visited" labels from historical log entries
- Round log timestamps to nearest half hour and distances to the nearest NM (0.5 NM minimum)
- Match log star rating spacing to planning view

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5399d5f24832b9faf700ae65a3e2a