### PR TITLE
Move log labels below entries

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -757,7 +757,7 @@ body {
 .historical-log-header,
 .historical-log-entry {
   display: grid;
-  grid-template-columns: 1.2fr 1fr 0.8fr 1.2fr 0.8fr auto;
+  grid-template-columns: 1.2fr 0.8fr 1.2fr 0.8fr auto;
   gap: 0.5em;
   align-items: center;
   padding: 0.6em 0.8em;
@@ -777,6 +777,8 @@ body {
 .historical-log-labels {
   display: flex;
   flex-wrap: wrap;
+  grid-column: 1 / -1;
+  margin-top: 0.3em;
 }
 .historical-log-labels .label {
   display: inline-block;

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1878,7 +1878,6 @@ renderHistoricalLog = function (logs = [], stops = []) {
   header.className = "historical-log-header";
   header.innerHTML = `
     <div>Place</div>
-    <div>Labels</div>
     <div>Distance</div>
     <div>Date</div>
     <div>Rating</div>
@@ -1949,11 +1948,11 @@ renderHistoricalLog = function (logs = [], stops = []) {
     div.className = "historical-log-entry";
     div.innerHTML = `
       <div class="historical-log-place">${l.cardName}</div>
-      <div class="historical-log-labels">${labelsHtml}</div>
       <div class="historical-log-distance">${distHtml}</div>
       <div class="historical-log-date">${dateStr}</div>
       <div class="historical-log-rating">${ratingHtml}</div>
       <div class="historical-log-links">${navily}${trello}</div>
+      <div class="historical-log-labels">${labelsHtml}</div>
     `;
     section.appendChild(div);
 


### PR DESCRIPTION
## Summary
- remove labels column from historical log view and show labels beneath each entry
- adjust log layout CSS to span labels across the entry

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b542f7bd1c832bab4fbf68f0347fb5