### PR TITLE
feat: allow editing labels in log view

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -779,6 +779,7 @@ body {
   flex-wrap: wrap;
   grid-column: 1 / -1;
   margin-top: 0.3em;
+  cursor: pointer;
 }
 .historical-log-labels .label {
   display: inline-block;
@@ -786,6 +787,10 @@ body {
   margin: 0 0.2em 0.2em 0;
   border-radius: 0.3em;
   font-size: 0.8em;
+}
+.historical-log-labels .label.placeholder {
+  background: #eee;
+  color: #333;
 }
 .historical-log-distance {
   color: #555;
@@ -823,10 +828,6 @@ body {
 }
 .label-editor label input {
   margin-right: 0.3em;
-}
-.label-editor button {
-  margin-top: 0.5em;
-  width: 100%;
 }
 
 @media (max-width: 600px) {

--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -806,6 +806,29 @@ body {
   font-size: 1.2em;
 }
 
+.label-editor {
+  position: absolute;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 0.5em;
+  border-radius: 0.4em;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+}
+.label-editor label {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.3em;
+  cursor: pointer;
+}
+.label-editor label input {
+  margin-right: 0.3em;
+}
+.label-editor button {
+  margin-top: 0.5em;
+  width: 100%;
+}
+
 @media (max-width: 600px) {
   .historical-log-header {
     display: none;

--- a/services/trello.js
+++ b/services/trello.js
@@ -6,7 +6,7 @@ const TOKEN      = process.env.TRELLO_TOKEN;
 const BASE_URL = `https://api.trello.com/1/boards/${BOARD_ID}`;
 const QUERY    = `?key=${KEY}&token=${TOKEN}`
   + `&cards=all&card_customFieldItems=true&lists=all&fields=all`
-  + `&customFields=true&members=all`;
+  + `&customFields=true&members=all&labels=all`;
 
 async function fetchBoard() {
   const { data } = await axios.get(BASE_URL + QUERY);


### PR DESCRIPTION
## Summary
- include board label data from Trello API
- add API to update card labels
- enable label editing in log view with a simple editor

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b548b047a8832b8fcfbfe3f9631627