### PR TITLE
Fetch only open cards and lists from Trello

### DIFF
--- a/services/trello.js
+++ b/services/trello.js
@@ -5,7 +5,7 @@ const TOKEN      = process.env.TRELLO_TOKEN;
 
 const BASE_URL = `https://api.trello.com/1/boards/${BOARD_ID}`;
 const QUERY    = `?key=${KEY}&token=${TOKEN}`
-  + `&cards=all&card_customFieldItems=true&lists=all&fields=all`
+  + `&cards=open&card_customFieldItems=true&lists=open&fields=all`
   + `&customFields=true&members=all&labels=all`;
 
 async function fetchBoard() {

--- a/services/trello.js
+++ b/services/trello.js
@@ -8,8 +8,14 @@ const QUERY    = `?key=${KEY}&token=${TOKEN}`
   + `&cards=open&card_customFieldItems=true&lists=open&fields=all`
   + `&customFields=true&members=all&labels=all`;
 
+function filterCardsToOpenLists(board) {
+  const openListIds = new Set(board.lists.map(list => list.id));
+  board.cards = board.cards.filter(card => openListIds.has(card.idList));
+}
+
 async function fetchBoard() {
   const { data } = await axios.get(BASE_URL + QUERY);
+  filterCardsToOpenLists(data);
   return data;
 }
 
@@ -44,6 +50,7 @@ async function fetchAllComments() {
 
 async function fetchBoardWithAllComments() {
   const { data: board } = await axios.get(BASE_URL + QUERY);
+  filterCardsToOpenLists(board);
   board.allComments = await fetchAllComments();
   return board;
 }


### PR DESCRIPTION
## Summary
- Limit Trello board queries to open cards and lists only

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b587cabffc832baf64efe5af5c36be