### PR TITLE
fix: allow planning first stop

### DIFF
--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -1907,6 +1907,11 @@ async function init() {
   const speedInput = document.getElementById("speed-input");
   plannedOnlyToggle = document.getElementById("planned-only-toggle");
 
+  // When there are no planned stops, show all places so users can plan the first one
+  if (stops.length === 0) {
+    plannedOnlyToggle.checked = false;
+  }
+
   renderMapWithToggle();
   renderTable(stops, parseFloat(speedInput.value));
   setupLogTab(stops);

--- a/public/js/captains-log.js
+++ b/public/js/captains-log.js
@@ -621,12 +621,15 @@ function initMap(stops, places, logs = null) {
         const originalText = btn.textContent;
         btn.textContent = "Planning...";
         const cardId = btn.getAttribute("data-card-id");
-        // Find the latest due date
+        // Find the latest due date (if any)
         const lastDue = stops
           .filter((s) => s.due)
           .map((s) => new Date(s.due))
           .sort((a, b) => b - a)[0];
-        const nextDue = new Date(lastDue);
+
+        // If there are no currently planned stops, start from today
+        const nextDue = lastDue ? new Date(lastDue) : new Date();
+        // Plan for the following day
         nextDue.setDate(nextDue.getDate() + 1);
         // Call backend to update the card's due date
         const res = await fetch(`/api/plan-stop`, {
@@ -737,12 +740,15 @@ function handlePlanButtonClicks() {
       );
       e.preventDefault();
       const cardId = btn.getAttribute("data-card-id");
-      // Find the latest due date
+      // Find the latest due date (if any)
       const lastDue = stops
         .filter((s) => s.due)
         .map((s) => new Date(s.due))
         .sort((a, b) => b - a)[0];
-      const nextDue = new Date(lastDue);
+
+      // Start from today if no stops are currently planned
+      const nextDue = lastDue ? new Date(lastDue) : new Date();
+      // Move to the following day for the new stop
       nextDue.setDate(nextDue.getDate() + 1);
       // Call backend to update the card's due date
       const res = await fetch(`/api/plan-stop`, {


### PR DESCRIPTION
## Summary
- handle absence of existing planned stops when choosing next due date, default to today +1 day

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c9a8bc9c832b8e86865a1ba5b341