### PR TITLE
Rename Location Log to Location Action and add action/litres/backfill support

### DIFF
--- a/public/css/captains-log.css
+++ b/public/css/captains-log.css
@@ -166,6 +166,18 @@ body {
   cursor: not-allowed;
 }
 
+.plan-btn-secondary {
+  background: #f8fafc;
+  color: #334155;
+  border-color: #cbd5e1;
+}
+
+.plan-btn-secondary:hover:not(:disabled) {
+  background: #f1f5f9;
+  color: #0f172a;
+  border-color: #94a3b8;
+}
+
 .popup-desc {
   margin-top: 0.3em;
   font-size: 0.9em;
@@ -1070,4 +1082,19 @@ body {
   display: flex;
   align-items: center;
   gap: 0.45rem;
+}
+
+.location-log-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.location-log-controls select,
+.location-log-controls input {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.95rem;
 }

--- a/views/captains-log.ejs
+++ b/views/captains-log.ejs
@@ -69,14 +69,39 @@
           <span>Show only planned stops on map</span>
         </label>
       </div>
-      <section class="location-log-panel" id="location-log-panel">
-        <h3>Location Log</h3>
-        <p class="muted">Use your current position to log arrived/departed comments.</p>
-        <button type="button" id="detect-location-log-btn" class="plan-btn">Detect location</button>
-        <div id="location-log-status" class="location-log-status"></div>
-        <div id="location-log-suggestions" class="location-log-suggestions"></div>
-        <button type="button" id="submit-location-log-btn" class="plan-btn" disabled>Post log comment</button>
-      </section>
+      <% if (user) { %>
+        <section class="location-log-panel" id="location-log-panel">
+          <h3>Location Action</h3>
+          <p class="muted">Use your current position and add a structured action comment.</p>
+          <button type="button" id="detect-location-log-btn" class="plan-btn">Detect location</button>
+          <div class="location-log-controls">
+            <label for="location-log-action">Action</label>
+            <select id="location-log-action">
+              <option value="arrived">Arrived</option>
+              <option value="departed">Departed</option>
+              <option value="water">Water</option>
+              <option value="diesel">Diesel</option>
+              <option value="bins">Bins</option>
+              <option value="bbq-gas-change">BBQ Gas Change</option>
+              <option value="gas-tank-change">Gas Tank Change</option>
+              <option value="power">Power</option>
+              <option value="boom">Boom</option>
+            </select>
+          </div>
+          <div class="location-log-controls" id="location-log-litres-wrap" hidden>
+            <label for="location-log-litres">Optional litres</label>
+            <input type="number" id="location-log-litres" min="0" step="1" placeholder="e.g. 30">
+          </div>
+          <button type="button" id="location-log-backfill-btn" class="plan-btn plan-btn-secondary">Backfill?</button>
+          <div class="location-log-controls" id="location-log-backfill-wrap" hidden>
+            <label for="location-log-backfill-time">Actual date/time</label>
+            <input type="datetime-local" id="location-log-backfill-time">
+          </div>
+          <div id="location-log-status" class="location-log-status"></div>
+          <div id="location-log-suggestions" class="location-log-suggestions"></div>
+          <button type="button" id="submit-location-log-btn" class="plan-btn" disabled>Post log comment</button>
+        </section>
+      <% } %>
       <div id="planning-summary" class="summary-panel"></div>
       <table id="planning-table" class="planning-table"></table>
     </div>


### PR DESCRIPTION
### Motivation
- Provide richer, structured logging from the planning panel so users can record actions beyond simple `arrived`/`departed` entries and optionally include fuel/water volumes and accurate timestamps.
- Ensure only authenticated users can post these structured log comments.

### Description
- Renamed the UI panel from "Location Log" to "Location Action" and render it only when `user` is present in the template (`views/captains-log.ejs`).
- Added an action picker with options: `Arrived`, `Departed`, `Water`, `Diesel`, `Bins`, `BBQ Gas Change`, `Gas Tank Change`, `Power`, and `Boom`, plus a conditional `Optional litres` numeric input shown for `Water`/`Diesel`, and a `Backfill?` button that reveals a `datetime-local` input to override the timestamp (`views/captains-log.ejs`, `public/js/captains-log.js`, `public/css/captains-log.css`).
- Updated client-side logic to validate the chosen action, include optional `litres` and an optional backfilled `timestamp` in the submission payload, and to pre-fill action from detection context when available (`public/js/captains-log.js`).
- Extended server-side `/api/log-entry` handling to accept the new action types and optional `litres`, validate inputs, and compose the comment headline as requested (e.g. `Diesel 30 litres` when litres supplied, otherwise the action label), while preserving the appended `timestamp`, `lat`, `lng`, and `source` lines (`routes/captainsLog.js`).
- Added minimal styles for the new controls and a secondary button style to match existing UI (`public/css/captains-log.css`).

### Testing
- Ran `npm test`, which reports the repo's default test script (`No tests specified`) and exited 0.
- Performed static checks with `node --check public/js/captains-log.js && node --check routes/captainsLog.js`, which completed without syntax errors.
- Ran `npm run lint`, which failed in this environment because the project has no ESLint configuration (reported to be expected here).
- Started the app with `npm start` successfully (server listening), and exercised the page via a headless browser to capture a screenshot, but a request for `/captains-log` returned a server error in this environment due to missing Trello credentials/API access when rendering board data.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e090062ec832b82ef588e61129366)